### PR TITLE
Add category filter; fix typos; edit webpack config

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -19,6 +19,7 @@ const webpackProxy = {
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
+  sassPrefix: '.ocp-advisor, .ocpAdvisor',
   ...(process.env.PROXY ? webpackProxy : insightsProxy),
 });
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -6,6 +6,7 @@ const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   ...(process.env.BETA && { deployment: 'beta/apps' }),
   debug: true,
+  sassPrefix: '.ocp-advisor, .ocpAdvisor',
 });
 
 plugins.push(

--- a/src/App.js
+++ b/src/App.js
@@ -28,9 +28,7 @@ const App = () => {
   return (
     <React.Fragment>
       <NotificationsPortal />
-      <div className="ocp-advisor">
-        <Routes />
-      </div>
+      <Routes />
     </React.Fragment>
   );
 };

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -44,6 +44,7 @@ export const RULE_CATEGORIES = {
   security: 2,
   fault_tolerance: 3,
   performance: 4,
+  osd_eligible: 5,
 };
 export const FILTER_CATEGORIES = {
   total_risk: {
@@ -138,6 +139,13 @@ export const FILTER_CATEGORIES = {
       {
         label: intlHelper(intl.formatMessage(messages.security), intlSettings),
         value: `${RULE_CATEGORIES.security}`,
+      },
+      {
+        label: intlHelper(
+          intl.formatMessage(messages.osdEligible),
+          intlSettings
+        ),
+        value: `${RULE_CATEGORIES.osd_eligible}`,
       },
     ],
   },

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -39,6 +39,12 @@ export const RISK_OF_CHANGE_LABEL = {
   3: intlHelper(intl.formatMessage(messages.moderate), intlSettings),
   4: intlHelper(intl.formatMessage(messages.high), intlSettings),
 };
+export const RULE_CATEGORIES = {
+  service_availability: 1,
+  security: 2,
+  fault_tolerance: 3,
+  performance: 4,
+};
 export const FILTER_CATEGORIES = {
   total_risk: {
     type: 'checkbox',
@@ -100,6 +106,38 @@ export const FILTER_CATEGORIES = {
       {
         label: intlHelper(intl.formatMessage(messages.disabled), intlSettings),
         value: 'disabled',
+      },
+    ],
+  },
+  category: {
+    type: 'checkbox',
+    title: 'category',
+    urlParam: 'category',
+    values: [
+      {
+        label: intlHelper(
+          intl.formatMessage(messages.serviceAvailability),
+          intlSettings
+        ),
+        value: `${RULE_CATEGORIES.service_availability}`,
+      },
+      {
+        label: intlHelper(
+          intl.formatMessage(messages.performance),
+          intlSettings
+        ),
+        value: `${RULE_CATEGORIES.performance}`,
+      },
+      {
+        label: intlHelper(
+          intl.formatMessage(messages.faultTolerance),
+          intlSettings
+        ),
+        value: `${RULE_CATEGORIES.fault_tolerance}`,
+      },
+      {
+        label: intlHelper(intl.formatMessage(messages.security), intlSettings),
+        value: `${RULE_CATEGORIES.security}`,
       },
     ],
   },

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -150,3 +150,6 @@ export const FILTER_CATEGORIES = {
     ],
   },
 };
+export const DEFAULT_CLUSTER_RULES_FILTERS = {
+  [FILTER_CATEGORIES.rule_status.urlParam]: 'enabled',
+};

--- a/src/Components/Breadcrumbs/Breadcrumbs.js
+++ b/src/Components/Breadcrumbs/Breadcrumbs.js
@@ -11,7 +11,6 @@ export const Breadcrumbs = ({ current, match }) => {
   const intl = useIntl();
   const [items, setItems] = useState([]);
   const buildBreadcrumbs = useCallback(() => {
-    console.log('meow');
     const crumbs = [];
     const splitUrl = match.url.split('/');
 

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -30,6 +30,7 @@ import {
   IMPACT_LABEL,
   LIKELIHOOD_LABEL,
   FILTER_CATEGORIES as FC,
+  RULE_CATEGORIES,
 } from '../../AppConstants';
 import ReportDetails from '../ReportDetails/ReportDetails';
 
@@ -136,12 +137,12 @@ const ClusterRules = ({ reports }) => {
                       <span>
                         The <strong>likelihood</strong> that this will be a
                         problem is{' '}
-                        {rule?.likelihood
-                          ? LIKELIHOOD_LABEL[rule?.likelihood]
+                        {rule.likelihood
+                          ? LIKELIHOOD_LABEL[rule.likelihood]
                           : 'unknown'}
                         . The <strong>impact</strong> of the problem would be{' '}
-                        {rule?.impact ? IMPACT_LABEL[rule?.impact] : 'unknown'}{' '}
-                        if it occurred.
+                        {rule.impact ? IMPACT_LABEL[rule.impact] : 'unknown'} if
+                        it occurred.
                       </span>
                     }
                   >
@@ -173,8 +174,15 @@ const ClusterRules = ({ reports }) => {
             const rowValue = {
               created_at: rule.created_at,
               total_risk: rule.total_risk,
-              tags: rule.tags,
+              category: rule.tags,
             };
+            if (key === 'category') {
+              // in that case, rowValue['category'] is an array of categories (or "tags" in the back-end implementation)
+              // e.g. ['security', 'fault_tolerance']
+              return rowValue[key].find((categoryName) =>
+                filterValues.includes(String(RULE_CATEGORIES[categoryName]))
+              );
+            }
             return filterValues.find(
               (value) => String(value) === String(rowValue[key])
             );
@@ -286,7 +294,7 @@ const ClusterRules = ({ reports }) => {
 
   const filterConfigItems = [
     {
-      label: 'description',
+      label: 'name',
       filterValues: {
         key: 'text-filter',
         onChange: (_e, value) => onInputChange(value),
@@ -304,6 +312,18 @@ const ClusterRules = ({ reports }) => {
           onFilterChange(FC.total_risk.urlParam, values),
         value: filters.total_risk,
         items: FC.total_risk.values,
+      },
+    },
+    {
+      label: FC.category.title,
+      type: FC.category.type,
+      id: FC.category.urlParam,
+      value: `checkbox-${FC.category.urlParam}`,
+      filterValues: {
+        key: `${FC.category.urlParam}-filter`,
+        onChange: (_e, values) => onFilterChange(FC.category.urlParam, values),
+        value: filters.category,
+        items: FC.category.values,
       },
     },
   ];

--- a/src/Components/RuleLabels/RuleLabels.js
+++ b/src/Components/RuleLabels/RuleLabels.js
@@ -1,0 +1,32 @@
+import {
+  Tooltip,
+  TooltipPosition,
+} from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
+
+import { Label } from '@patternfly/react-core/dist/js/components/Label/Label';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useIntl } from 'react-intl';
+import messages from '../../Messages';
+
+const RuleLabels = ({ rule }) => {
+  const intl = useIntl();
+  return (
+    <React.Fragment>
+      {rule.disabled && (
+        <Tooltip
+          content={intl.formatMessage(messages.ruleIsDisabledTooltip)}
+          position={TooltipPosition.right}
+        >
+          <Label color="gray">{intl.formatMessage(messages.disabled)}</Label>
+        </Tooltip>
+      )}
+    </React.Fragment>
+  );
+};
+
+RuleLabels.propTypes = {
+  rule: PropTypes.object,
+};
+
+export default RuleLabels;

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -209,4 +209,11 @@ export default defineMessages({
     id: 'noRecommendationsDesc',
     defaultMessage: 'No known recommendations affect this cluster.',
   },
+  ruleIsDisabledTooltip: {
+    id: 'ruleIsDisabledTooltip',
+    description:
+      'Disabled badge tooltip explaining the meaning of a disabled recommendation',
+    defaultMessage:
+      'Indicates this recommendation will not be shown for the cluster.',
+  },
 });

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -126,6 +126,11 @@ export default defineMessages({
     description: 'Filter value',
     defaultMessage: 'Security',
   },
+  osdEligible: {
+    id: 'osdEligible',
+    description: 'Filter value',
+    defaultMessage: 'OSD Eligible',
+  },
   enabled: {
     id: 'enabled',
     description: 'Filter value',

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -106,20 +106,20 @@ export default defineMessages({
     description: 'Filter value',
     defaultMessage: 'High',
   },
-  availability: {
-    id: 'availability',
+  serviceAvailability: {
+    id: 'serviceAvailability',
     description: 'Filter value',
-    defaultMessage: 'Availability',
+    defaultMessage: 'Service Availability',
   },
   performance: {
     id: 'performance',
     description: 'Filter value',
     defaultMessage: 'Performance',
   },
-  stability: {
-    id: 'stability',
+  faultTolerance: {
+    id: 'faultTolerance',
     description: 'Filter value',
-    defaultMessage: 'Stability',
+    defaultMessage: 'Fault Tolerance',
   },
   security: {
     id: 'security',

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -9,7 +9,8 @@ export const smartProxyApi = createApi({
   }),
   endpoints: (builder) => ({
     getClusterById: builder.query({
-      query: (id) => `clusters/${id}/report`,
+      query: (id, includeDisabled = true) =>
+        `clusters/${id}/report?get_disabled=${includeDisabled}`,
     }),
   }),
 });


### PR DESCRIPTION
- [x] Add filter by categories to the rules table on Cluster Details view.
- [x] Add `sassPrefix` to the webpack config and remove unnecessary .ocp-advisor wrapper.
- [x] Add filter by rule status.
- [x] Add 'Disabled' label after disabled rules.