### PR TITLE
Pass impact number to  rule details component

### DIFF
--- a/src/Components/Recommendation/Recommendation.js
+++ b/src/Components/Recommendation/Recommendation.js
@@ -44,8 +44,8 @@ const Recommendation = ({ rule, match }) => {
       ...errorKeyContent.metadata,
     };
     adjusted.impact = {
-      name: adjusted.impact,
-      impact: IMPACT_VALUES[adjusted.impact],
+      name: IMPACT_VALUES[adjusted.impact],
+      impact: adjusted.impact,
     };
     delete adjusted.metadata;
     delete adjusted.error_keys;


### PR DESCRIPTION
The Smart Proxy API started sending number coefficient instead of the textual representation for the `impact` field. The patch changes the behavior for the "adjusting" function.