### PR TITLE
Error Boundary for OCP Advisor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,10 +28,8 @@ const App = () => {
 
   return (
     <ErrorBoundary>
-      <React.Fragment>
-        <NotificationsPortal />
-        <Routes />
-      </React.Fragment>
+      <NotificationsPortal />
+      <Routes />
     </ErrorBoundary>
   );
 };

--- a/src/Utilities/ErrorBoundary.js
+++ b/src/Utilities/ErrorBoundary.js
@@ -3,30 +3,30 @@ import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { ErrorState } from '../Components/MessageState/EmptyStates';
+import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye/Bullseye';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       hasError: false,
-      error: null,
     };
   }
 
-  componentDidCatch(error) {
+  componentDidCatch() {
     this.setState({
       hasError: true,
-      error: error.toString(),
     });
   }
 
   render() {
-    const { error } = this.state;
-    if (error) {
-      return <ErrorState />;
-    }
-
-    return this.props.children;
+    return this.state.hasError ? (
+      <Bullseye>
+        <ErrorState />
+      </Bullseye>
+    ) : (
+      this.props.children
+    );
   }
 }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-6220

Created an Error Boundary component for OCP Advisor based on a React documentation

To test that the Fallback UI component works I added text to it "THIS IS A TEST"
![image](https://user-images.githubusercontent.com/62722417/138690392-ad6e1bf6-cb08-4ee7-b1c8-60b88a226068.png)

In reality, it will look like that without any "marks" 
![image](https://user-images.githubusercontent.com/62722417/138690299-81d10ef3-d9c3-427d-81c9-6af17ec7d336.png)

As a plus from now on the Errors will be shown in a more cohesive and readable manner.
This screenshot show an error that I triggered to test the functionality of the Error Boundary Component
![image](https://user-images.githubusercontent.com/62722417/138679958-6712a056-60ff-4fb9-b1ec-5271558e86b3.png)
