### PR TITLE
Redirect from root to the recommendations page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,4 +1,4 @@
-import { Route, Switch } from 'react-router-dom';
+import { Route, Switch, Redirect } from 'react-router-dom';
 import React, { Suspense, lazy } from 'react';
 
 import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye';
@@ -58,6 +58,7 @@ export const Routes = () => (
       {paths.map((path) => (
         <Route key={path.title} path={path.path} component={path.component} />
       ))}
+      <Redirect exact from="/" to="/recommendations" />
       {/* Finally, catch all unmatched routes */}
       <Route
         path="*"


### PR DESCRIPTION
When users open the root page (e.g., from the navigation menu), redirect them to the `/recommendations` page.