### PR TITLE
Fetch both impacting and non-impacting recs

### DIFF
--- a/src/Components/RecsListTable/index.js
+++ b/src/Components/RecsListTable/index.js
@@ -48,7 +48,7 @@ const RecsListTable = () => {
   const dispatch = useDispatch();
   const filters = useSelector(({ filters }) => filters.recsListState);
   const { isError, isUninitialized, isFetching, isSuccess, data } =
-    useGetRecsQuery({ impacting: false });
+    useGetRecsQuery();
   const recs = data?.recommendations || [];
   const page = filters.offset / filters.limit + 1;
   const [filteredRows, setFilteredRows] = useState([]);

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -21,7 +21,7 @@ export const SmartProxyApi = createApi({
       transformResponse: (response) => response?.data,
     }),
     getRecs: builder.query({
-      query: (params) => `v2/rule?impacting=${params.impacting}`,
+      query: () => `v2/rule`,
     }),
   }),
 });


### PR DESCRIPTION
The patch follows the updates for the API server, which has changed the behavior of the `/rule` GET endpoint for the `impacting` parameter. We remove the parameter in the request so that we don't limit the response with only non-impacting recommendations.