### PR TITLE
Wrap app with auth check

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -48,6 +48,8 @@
   "none": "None",
   "oneOrMore": "1 or more",
   "performance": "Performance",
+  "permsBody": "To view the content of this page, you must be granted a minimum of Advisor permissions from your Organization Administrator.",
+  "permsTitle": "You do not have access to Advisor",
   "recommendation": "Recommendation",
   "recommendations": "Recommendations",
   "resetFilters": "Reset filters",

--- a/src/App.js
+++ b/src/App.js
@@ -1,37 +1,67 @@
 import './App.scss';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Provider } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { useIntl } from 'react-intl';
+import PropTypes from 'prop-types';
 
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry/Registry';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye/Bullseye';
+import LockIcon from '@patternfly/react-icons/dist/esm/icons/lock-icon';
 
 import { Routes } from './Routes';
 import ErrorBoundary from './Utilities/ErrorBoundary';
+import MessageState from './Components/MessageState/MessageState';
+import messages from './Messages';
+import getStore from './Store';
 
-const App = () => {
+const App = ({ useLogger }) => {
+  const intl = useIntl();
   const history = useHistory();
+  const [auth, setAuth] = useState(false);
 
   useEffect(() => {
     const registry = getRegistry();
     registry.register({ notifications: notificationsReducer });
     insights.chrome.init();
+    insights.chrome.auth.getUser().then(() => setAuth(true));
     insights.chrome.identifyApp('ocp-advisor');
     const unregister = insights.chrome.on('APP_NAVIGATION', (event) =>
       history.push(`/${event.navId}`)
     );
-    return () => {
-      unregister();
-    };
+    return () => unregister();
   }, []);
 
   return (
     <ErrorBoundary>
-      <NotificationsPortal />
-      <Routes />
+      {auth ? (
+        <Provider store={getStore(useLogger)}>
+          <NotificationsPortal />
+          <Routes />
+        </Provider>
+      ) : (
+        <Bullseye>
+          <MessageState
+            variant="large"
+            icon={LockIcon}
+            title={intl.formatMessage(messages.permsTitle)}
+            text={intl.formatMessage(messages.permsBody)}
+          />
+        </Bullseye>
+      )}
     </ErrorBoundary>
   );
+};
+
+App.propTypes = {
+  useLogger: PropTypes.bool,
+};
+
+App.defaultProps = {
+  useLogger: false,
 };
 
 export default App;

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,30 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { Provider } from 'react-redux';
 
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations/';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers/helpers';
 
 import App from './App';
-import getStore from './Store';
 
 const translations = {
   en: require('../compiled-lang/en.json'),
 };
 
-const AppEntry = (useLogger) => (
+const AppEntry = ({ useLogger }) => (
   <IntlProvider
     locale={navigator.language.slice(0, 2)}
     defaultLocale="en"
     messages={translations[navigator.language.slice(0, 2)]}
     onError={console.error}
   >
-    <Provider store={getStore(useLogger)}>
-      <Router basename={getBaseName(window.location.pathname, 3)}>
-        <App />
-      </Router>
-    </Provider>
+    <Router basename={getBaseName(window.location.pathname, 3)}>
+      <App useLogger={useLogger} />
+    </Router>
   </IntlProvider>
 );
 

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -367,4 +367,15 @@ export default defineMessages({
     description: 'Abreviated as N/A, text equivelent, not applicable',
     defaultMessage: 'N/A',
   },
+  permsTitle: {
+    id: 'permsTitle',
+    description: 'You do not have access to Advisor',
+    defaultMessage: 'You do not have access to Advisor',
+  },
+  permsBody: {
+    id: 'permsBody',
+    description: 'To view the content',
+    defaultMessage:
+      'To view the content of this page, you must be granted a minimum of Advisor permissions from your Organization Administrator.',
+  },
 });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-6237.

Introduces authentication check and wrapper for Advisor. Once the user has authenticated within insights chroming, the content of Advisor is exposed. The redux store is also now not initialized, while the user has not passed auth check.

![Screenshot 2021-11-03 at 13-51-57 0f9b7635-b5bf-4a6f-be8e-644cfb60a794 - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140065044-96e5dd59-94e7-4e7f-8db3-ea4fadaa41c2.png)
