### PR TITLE
Always show header with breadcrumb for single cluster page

### DIFF
--- a/src/Components/Cluster/Cluster.js
+++ b/src/Components/Cluster/Cluster.js
@@ -19,7 +19,7 @@ import MessageState from '../MessageState/MessageState';
 import Loading from '../Loading/Loading';
 import messages from '../../Messages';
 
-export const Cluster = ({ cluster, match }) => {
+export const Cluster = ({ cluster, displayName, match }) => {
   const intl = useIntl();
   const {
     isError,
@@ -30,9 +30,17 @@ export const Cluster = ({ cluster, match }) => {
     data,
     error,
   } = cluster;
+  const { data: clusterDisplayName } = displayName;
 
   return (
     <React.Fragment>
+      <PageHeader className="pf-m-light ins-inventory-detail">
+        <Breadcrumbs
+          current={clusterDisplayName || match.params.clusterId}
+          match={match}
+        />
+        <ClusterHeader />
+      </PageHeader>
       {(isUninitialized || isLoading || isFetching) && (
         <Main>
           <Loading />
@@ -69,10 +77,6 @@ export const Cluster = ({ cluster, match }) => {
         ))}
       {isSuccess && (
         <React.Fragment>
-          <PageHeader className="pf-m-light ins-inventory-detail">
-            <Breadcrumbs current={match.params.clusterId} match={match} />
-            <ClusterHeader />
-          </PageHeader>
           <Main>
             <React.Fragment>
               <Grid hasGutter>
@@ -90,5 +94,6 @@ export const Cluster = ({ cluster, match }) => {
 
 Cluster.propTypes = {
   cluster: PropTypes.object.isRequired,
+  displayName: PropTypes.object.isRequired,
   match: PropTypes.object.isRequired,
 };

--- a/src/Components/Cluster/Cluster.test.js
+++ b/src/Components/Cluster/Cluster.test.js
@@ -18,6 +18,9 @@ describe('<Cluster /> test', () => {
         isSuccess: true,
         data: {},
       },
+      displayName: {
+        data: 'display-name-123',
+      },
       match: {
         params: {
           clusterId: 'foobar',

--- a/src/Components/Cluster/__snapshots__/Cluster.test.js.snap
+++ b/src/Components/Cluster/__snapshots__/Cluster.test.js.snap
@@ -6,7 +6,7 @@ exports[`<Cluster /> test renders correctly 1`] = `
     className="pf-m-light ins-inventory-detail"
   >
     <Breadcrumbs
-      current="foobar"
+      current="display-name-123"
       match={
         Object {
           "params": Object {
@@ -36,6 +36,22 @@ exports[`<Cluster /> test renders correctly 1`] = `
 
 exports[`<Cluster /> test renders correctly when cluster loading 1`] = `
 <Fragment>
+  <PageHeader
+    className="pf-m-light ins-inventory-detail"
+  >
+    <Breadcrumbs
+      current="display-name-123"
+      match={
+        Object {
+          "params": Object {
+            "clusterId": "foobar",
+          },
+          "url": "foobar",
+        }
+      }
+    />
+    <mockConstructor />
+  </PageHeader>
   <Connect(Main)>
     <Loading />
   </Connect(Main)>
@@ -44,6 +60,22 @@ exports[`<Cluster /> test renders correctly when cluster loading 1`] = `
 
 exports[`<Cluster /> test renders correctly when cluster unavailable 1`] = `
 <Fragment>
+  <PageHeader
+    className="pf-m-light ins-inventory-detail"
+  >
+    <Breadcrumbs
+      current="display-name-123"
+      match={
+        Object {
+          "params": Object {
+            "clusterId": "foobar",
+          },
+          "url": "foobar",
+        }
+      }
+    />
+    <mockConstructor />
+  </PageHeader>
   <Connect(Main)>
     <MessageState
       icon={[Function]}

--- a/src/Components/Cluster/index.js
+++ b/src/Components/Cluster/index.js
@@ -5,10 +5,12 @@ import { useIntl } from 'react-intl';
 import { useGetClusterByIdQuery } from '../../Services/SmartProxy';
 import messages from '../../Messages';
 import { Cluster } from './Cluster';
+import { useGetClusterDisplayNameByIdQuery } from '../../Services/AccountManagementService';
 
 export default routerParams(({ match }) => {
   const intl = useIntl();
   const cluster = useGetClusterByIdQuery(match.params.clusterId);
+  const displayName = useGetClusterDisplayNameByIdQuery(match.params.clusterId);
 
   useEffect(() => {
     cluster.refetch();
@@ -23,5 +25,5 @@ export default routerParams(({ match }) => {
     }
   }, [match.params.clusterId]);
 
-  return <Cluster cluster={cluster} match={match} />;
+  return <Cluster cluster={cluster} displayName={displayName} match={match} />;
 });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-6390.

- Makes the single cluster page show the breadcrumb with information about the requested cluster.
- When a display name is available, show it instead of cluster id.

![Screenshot 2021-11-04 at 12-16-53 5d5892d3-1f74-4ccf-91af-548dfc976 - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140304611-9b6e7a10-ddca-4d46-b06c-28e7fa8e66c8.png)

![Screenshot 2021-11-04 at 12-08-13 0f9b7635-b5bf-4a6f-be8e-644cfb60a794 - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140304615-03b2d1a4-218f-4a11-aa49-48dd45f4f7fd.png)

![Screenshot 2021-11-04 at 12-07-58 d50d0126-c90b-4428-a75f-dc08cd02960b - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140304618-d1432aff-5bb1-4211-9aaa-332f7bd1cbc3.png)

![Screenshot 2021-11-04 at 12-07-38 e2189f4e-d9e8-44ab-a4b5-e5d96a98f60e - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140304620-9165c6db-1bf0-4316-8391-1c4108d57f8e.png)
