### PR TITLE
Remove select feature; utilize stage AMS API for pre-prod envs

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -37,7 +37,7 @@
   "noClustersErrorDesc": "There was an error fetching affected clusters for this recommendation.",
   "noMatchingClustersDesc": "To continue, edit your filter settings and search again.",
   "noMatchingClustersTitle": "No matching clusters found",
-  "noMatchingRecommendationsDesc": "This filter criteria matches no recommendations. Try changing your filter settings.",
+  "noMatchingRecommendationsDesc": "To continue, edit your filter settings and search again.",
   "noMatchingRecommendationsTitle": "No matching recommendations found",
   "noRecommendations": "The cluster is not affected by any known recommendations",
   "noRecommendationsDesc": "No known recommendations affect this cluster.",

--- a/config/cypress.webpack.config.js
+++ b/config/cypress.webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack');
+
 module.exports = {
   module: {
     rules: [
@@ -23,4 +25,7 @@ module.exports = {
   resolve: {
     extensions: ['*', '.js', '.jsx'],
   },
+  plugins: [
+    new webpack.DefinePlugin({ insights: { chrome: { isProd: false } } }),
+  ],
 };

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -43,7 +43,6 @@ const ClusterRules = ({ reports }) => {
   const [sortBy, setSortBy] = useState({});
   const [filters, setFilters] = useState(DEFAULT_CLUSTER_RULES_FILTERS);
   const [searchValue, setSearchValue] = useState('');
-  const [isSelected, setIsSelected] = useState(false);
   const [rows, setRows] = useState([]);
   const results = rows ? rows.length / 2 : 0;
 
@@ -101,7 +100,6 @@ const ClusterRules = ({ reports }) => {
         (rowVal, rowKey) =>
           rowKey % 2 === 0 && rowVal.rule.rule_id === rule.rule_id && rowVal
       );
-      const selected = entity.length ? entity[0].selected : false;
       const isOpen = rows.length
         ? entity.length
           ? entity[0].isOpen
@@ -115,7 +113,6 @@ const ClusterRules = ({ reports }) => {
           rule,
           resolution,
           isOpen,
-          selected,
           cells: [
             {
               title: (
@@ -218,9 +215,9 @@ const ClusterRules = ({ reports }) => {
 
   const onSort = (_e, index, direction) => {
     const sortedReports = {
-      2: 'description',
-      3: 'created_at',
-      4: 'total_risk',
+      1: 'description',
+      2: 'created_at',
+      3: 'total_risk',
     };
     const sort = () =>
       activeReports
@@ -241,52 +238,6 @@ const ClusterRules = ({ reports }) => {
       direction,
     });
     setRows(buildRows(sortedReportsDirectional, filters, rows, searchValue));
-  };
-
-  const onRowSelect = (_e, isSelected, rowId) =>
-    setRows(
-      buildRows(
-        activeReports,
-        filters,
-        rows.map((row, index) =>
-          index === rowId ? { ...row, selected: isSelected } : row
-        ),
-        searchValue
-      )
-    );
-
-  const getSelectedItems = (rows) => rows.filter((entity) => entity.selected);
-  const selectedItemsLength = getSelectedItems(rows).length;
-
-  const onBulkSelect = (isSelected) => {
-    setIsSelected(isSelected);
-    setRows(
-      buildRows(
-        activeReports,
-        filters,
-        rows.map((row, index) =>
-          index % 2 === 0 ? { ...row, selected: isSelected } : row
-        ),
-        searchValue
-      )
-    );
-  };
-
-  const bulkSelect = {
-    items: [
-      {
-        title: 'Select none',
-        onClick: () => onBulkSelect(false),
-      },
-      {
-        title: 'Select all',
-        onClick: () => onBulkSelect(true),
-      },
-    ],
-    count: selectedItemsLength,
-    checked: isSelected,
-    onSelect: () => onBulkSelect(!isSelected),
-    ouiaId: 'bulk-selector',
   };
 
   const onInputChange = (value) => {
@@ -443,7 +394,6 @@ const ClusterRules = ({ reports }) => {
     <div id="cluster-recs-list-table">
       <PrimaryToolbar
         actionsConfig={{ actions }}
-        bulkSelect={bulkSelect}
         filterConfig={{ items: filterConfigItems, isDisabled: results === 0 }}
         pagination={
           <React.Fragment>
@@ -459,12 +409,10 @@ const ClusterRules = ({ reports }) => {
           <Table
             aria-label={'Cluster recommendations table'}
             ouiaId={'cluster-recommendations'}
-            onSelect={onRowSelect}
             onCollapse={handleOnCollapse}
             rows={rows}
             cells={cols}
             sortBy={sortBy}
-            canSelectAll={false}
             onSort={onSort}
             variant={TableVariant.compact}
             isStickyHeader

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -195,8 +195,7 @@ export default defineMessages({
   },
   noMatchingRecsBody: {
     id: 'noMatchingRecommendationsDesc',
-    defaultMessage:
-      'This filter criteria matches no recommendations. Try changing your filter settings.',
+    defaultMessage: 'To continue, edit your filter settings and search again.',
   },
   noRecommendations: {
     id: 'noRecommendations',

--- a/src/Services/AccountManagementService.js
+++ b/src/Services/AccountManagementService.js
@@ -1,6 +1,8 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
-const BASE_URL = 'https://api.openshift.com/api/accounts_mgmt/v1';
+const BASE_URL = insights.chrome.isProd
+  ? 'https://api.openshift.com/api/accounts_mgmt/v1'
+  : 'https://api.stage.openshift.com/api/accounts_mgmt/v1';
 
 export const AmsApi = createApi({
   reducerPath: 'ams',


### PR DESCRIPTION
- For the single cluster page, remove the bulk select and all select-related features from the recommendations table. (See screenshot 1)
- When deployed in pre-prod envs (e.g. qa/beta), use AMS API in the stage environment.
- Change empty state body message for the rules table (screenshot 2).

![Screenshot 2021-11-05 at 11-50-39 576968e7-b50e-4723-8952-81b0477b6f4f - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140499713-9a05cd09-8280-4203-9da8-a804daef35c2.png)


![Screenshot 2021-11-05 at 12-03-37 OCP Advisor Insights](https://user-images.githubusercontent.com/31385370/140500997-da46f7ad-1958-444f-9161-8e83814be3b4.png)
