### PR TITLE
Enable filter toolbar for cluster with disabled recs

### DIFF
--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -353,7 +353,9 @@ const ClusterRules = ({ reports }) => {
 
   const onChipDelete = (_e, itemsToRemove, isAll) => {
     if (isAll) {
-      setRows(buildRows(activeReports, {}, rows, ''));
+      setRows(
+        buildRows(activeReports, DEFAULT_CLUSTER_RULES_FILTERS, rows, '')
+      );
       setFilters(DEFAULT_CLUSTER_RULES_FILTERS);
       setSearchValue('');
     } else {
@@ -394,7 +396,10 @@ const ClusterRules = ({ reports }) => {
     <div id="cluster-recs-list-table">
       <PrimaryToolbar
         actionsConfig={{ actions }}
-        filterConfig={{ items: filterConfigItems, isDisabled: results === 0 }}
+        filterConfig={{
+          items: filterConfigItems,
+          isDisabled: activeReports.length === 0,
+        }}
         pagination={
           <React.Fragment>
             {results === 1
@@ -402,7 +407,9 @@ const ClusterRules = ({ reports }) => {
               : `${results} ${intl.formatMessage(messages.recommendations)}`}
           </React.Fragment>
         }
-        activeFiltersConfig={results === 0 ? undefined : activeFiltersConfig}
+        activeFiltersConfig={
+          activeReports.length === 0 ? undefined : activeFiltersConfig
+        }
       />
       {activeReports.length > 0 ? (
         <React.Fragment>


### PR DESCRIPTION
Fixes the toolbar for clusters that have recommendations hitting; however, all of them are disabled. 

Before:
![Screenshot 2021-11-08 at 09-01-25 ee7d2bf4-8933-4a3a-8634-3328fe806e08 - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140705122-d28d70f0-4a8f-4b35-a112-b9a0963de17d.png)

After (the cluster is the same):
![Screenshot 2021-11-08 at 09-02-51 ee7d2bf4-8933-4a3a-8634-3328fe806e08 - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/140705138-b6dd805c-febf-45d3-b603-9bea8249edf9.png)
