### PR TITLE
Added expand/collapse all button with icon to the Primary toolbar

### DIFF
--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -83,7 +83,7 @@ const RecsListTable = ({ query }) => {
       .filter((rule) => passFilters(rule, filters))
       .map((value, key) => [
         {
-          isOpen: false,
+          isOpen: isAllExpanded ? true : false,
           rule: value,
           cells: [
             {

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -3,7 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-
+import { Button } from '@patternfly/react-core/dist/js/components/Button';
+import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
+import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
 import {
   SortByDirection,
   Table,
@@ -59,6 +61,7 @@ const RecsListTable = ({ query }) => {
   const [displayedRows, setDisplayedRows] = useState([]);
   const [disableRuleOpen, setDisableRuleOpen] = useState(false);
   const [selectedRule, setSelectedRule] = useState({});
+  const [expandedTable, setExpandedTable] = useState(true);
   const notify = (data) => dispatch(addNotification(data));
 
   useEffect(() => {
@@ -418,6 +421,21 @@ const RecsListTable = ({ query }) => {
     },
   };
 
+  //Responsible for the handling collapse for all the recommendations
+  //Used in the PrimaryToolbar
+  const collapseAll = (collapse) => {
+    setExpandedTable(!collapse);
+    setDisplayedRows(
+      displayedRows.map((row) => {
+        return {
+          ...row,
+          isOpen: collapse,
+        };
+      })
+    );
+  };
+
+  //Responsible for handling collapse for single recommendation
   const handleOnCollapse = (_e, rowId, isOpen) => {
     const collapseRows = [...displayedRows];
     collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
@@ -497,6 +515,27 @@ const RecsListTable = ({ query }) => {
         />
       )}
       <PrimaryToolbar
+        actionsConfig={{
+          actions: [
+            expandedTable === true ? (
+              <Button
+                variant="plain"
+                key="first"
+                onClick={() => collapseAll(true)}
+              >
+                <AngleRightIcon />
+              </Button>
+            ) : (
+              <Button
+                variant="plain"
+                key="first"
+                onClick={() => collapseAll(false)}
+              >
+                <AngleDownIcon />
+              </Button>
+            ),
+          ],
+        }}
         pagination={{
           itemCount: filteredRows.length,
           page: filters.offset / filters.limit + 1,
@@ -516,6 +555,7 @@ const RecsListTable = ({ query }) => {
         }}
         filterConfig={{ items: filterConfigItems }}
         activeFiltersConfig={activeFiltersConfig}
+        isExpanded="false"
       />
       {(isUninitialized || isFetching) && <Loading />}
       {(isError || (isSuccess && recs.length === 0)) && (

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -3,9 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Button } from '@patternfly/react-core/dist/js/components/Button';
-import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
-import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
 import {
   SortByDirection,
   Table,
@@ -61,7 +58,7 @@ const RecsListTable = ({ query }) => {
   const [displayedRows, setDisplayedRows] = useState([]);
   const [disableRuleOpen, setDisableRuleOpen] = useState(false);
   const [selectedRule, setSelectedRule] = useState({});
-  const [expandedTable, setExpandedTable] = useState(true);
+  const [isAllExpanded, setIsAllExpanded] = useState(false);
   const notify = (data) => dispatch(addNotification(data));
 
   useEffect(() => {
@@ -423,13 +420,13 @@ const RecsListTable = ({ query }) => {
 
   //Responsible for the handling collapse for all the recommendations
   //Used in the PrimaryToolbar
-  const collapseAll = (collapse) => {
-    setExpandedTable(!collapse);
+  const collapseAll = (_e, isOpen) => {
+    setIsAllExpanded(isOpen);
     setDisplayedRows(
       displayedRows.map((row) => {
         return {
           ...row,
-          isOpen: collapse,
+          isOpen: isOpen,
         };
       })
     );
@@ -515,27 +512,7 @@ const RecsListTable = ({ query }) => {
         />
       )}
       <PrimaryToolbar
-        actionsConfig={{
-          actions: [
-            expandedTable === true ? (
-              <Button
-                variant="plain"
-                key="first"
-                onClick={() => collapseAll(true)}
-              >
-                <AngleRightIcon />
-              </Button>
-            ) : (
-              <Button
-                variant="plain"
-                key="first"
-                onClick={() => collapseAll(false)}
-              >
-                <AngleDownIcon />
-              </Button>
-            ),
-          ],
-        }}
+        expandAll={{ isAllExpanded, onClick: collapseAll }}
         pagination={{
           itemCount: filteredRows.length,
           page: filters.offset / filters.limit + 1,
@@ -555,7 +532,6 @@ const RecsListTable = ({ query }) => {
         }}
         filterConfig={{ items: filterConfigItems }}
         activeFiltersConfig={activeFiltersConfig}
-        isExpanded="false"
       />
       {(isUninitialized || isFetching) && <Loading />}
       {(isError || (isSuccess && recs.length === 0)) && (

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -83,7 +83,7 @@ const RecsListTable = ({ query }) => {
       .filter((rule) => passFilters(rule, filters))
       .map((value, key) => [
         {
-          isOpen: isAllExpanded ? true : false,
+          isOpen: isAllExpanded,
           rule: value,
           cells: [
             {


### PR DESCRIPTION
Described status expanded true/false in the state using useState
used property expandAll of PrimaryToolbar to pass it function collapseAll
![image](https://user-images.githubusercontent.com/62722417/145973068-630b3609-9768-4ff6-b951-28d6cb3a2957.png)
