### PR TITLE
Improve page document titles; affected clusters table enhancements

### DIFF
--- a/cypress/fixtures/AffectedClustersTable/data.json
+++ b/cypress/fixtures/AffectedClustersTable/data.json
@@ -1,25 +1,34 @@
 [
-  { "cluster": "694d3942-9cb7-42b8-aad2-1f28cc7f0a3b" },
-  { "cluster": "bcbd9c24-bf3f-4141-9a6c-019f5404164e" },
-  { "cluster": "685de527-ad9e-426c-a83f-07d797dd28e8" },
-  { "cluster": "4bc920df-7935-4882-a946-e1e735439620" },
-  { "cluster": "41c30565-b4c9-49f2-a4ce-3277ad22b258" },
-  { "cluster": "6810f59e-c37c-420a-ae52-c23ccaccffc9" },
-  { "cluster": "5d5892d3-1f74-4ccf-22af-548dfc9767bb" },
-  { "cluster": "444cf4e5-a983-4894-9852-cb8b441b7006" },
-  { "cluster": "00d404e4-9e83-46ee-9ddd-83c06fa65d67" },
-  { "cluster": "e73ee8b2-f60f-4bb0-abc7-be3093debfe7" },
-  { "cluster": "f7331e9a-2f59-484d-af52-338d56165df5" },
-  { "cluster": "56f646b2-cf9f-46b2-9553-0e399465b966" },
-  { "cluster": "e508506a-6cac-4925-9582-fdc0338e1020" },
-  { "cluster": "bb7c5181-5464-4979-90de-135e38c8794a" },
-  { "cluster": "6367317a-5ffe-472c-a9dc-70d8a67485b4" },
-  { "cluster": "a7fc5b1a-d3f3-4103-91d3-f1cf560a1910" },
-  { "cluster": "40dbef1f-0382-4342-8e4e-c2bf299928c5" },
-  { "cluster": "96c55abf-db62-4e99-b01a-9331a757097f" },
-  { "cluster": "dd2ef343-9131-46f5-8962-290fdfdf2199" },
-  { "cluster": "90f9a6ea-f79a-4d8d-a889-f0fb151aca5e" },
-  { "cluster": "ff41a4ee-aa2c-43a2-ac65-d5956252416d" },
-  { "cluster": "020cc0a1-6f1a-45fa-9780-3f4e74590902" },
-  { "cluster": "75400997-78fe-404e-a900-1c630bc3501d" }
+  { "cluster": "694d3942-9cb7-42b8-aad2-1f28cc7f0a3b", "cluster_name": "" },
+  { "cluster": "bcbd9c24-bf3f-4141-9a6c-019f5404164e", "cluster_name": "" },
+  {
+    "cluster": "685de527-ad9e-426c-a83f-07d797dd28e8",
+    "cluster_name": "foobar cluster"
+  },
+  { "cluster": "4bc920df-7935-4882-a946-e1e735439620", "cluster_name": "" },
+  { "cluster": "41c30565-b4c9-49f2-a4ce-3277ad22b258", "cluster_name": "" },
+  {
+    "cluster": "6810f59e-c37c-420a-ae52-c23ccaccffc9",
+    "cluster_name": "custom cluster name 1"
+  },
+  { "cluster": "5d5892d3-1f74-4ccf-22af-548dfc9767bb", "cluster_name": "" },
+  { "cluster": "444cf4e5-a983-4894-9852-cb8b441b7006", "cluster_name": "" },
+  { "cluster": "00d404e4-9e83-46ee-9ddd-83c06fa65d67", "cluster_name": "" },
+  { "cluster": "e73ee8b2-f60f-4bb0-abc7-be3093debfe7", "cluster_name": "" },
+  {
+    "cluster": "f7331e9a-2f59-484d-af52-338d56165df5",
+    "cluster_name": "custom cluster name 2"
+  },
+  { "cluster": "56f646b2-cf9f-46b2-9553-0e399465b966", "cluster_name": "" },
+  { "cluster": "e508506a-6cac-4925-9582-fdc0338e1020", "cluster_name": "" },
+  { "cluster": "bb7c5181-5464-4979-90de-135e38c8794a", "cluster_name": "" },
+  { "cluster": "6367317a-5ffe-472c-a9dc-70d8a67485b4", "cluster_name": "" },
+  { "cluster": "a7fc5b1a-d3f3-4103-91d3-f1cf560a1910", "cluster_name": "" },
+  { "cluster": "40dbef1f-0382-4342-8e4e-c2bf299928c5", "cluster_name": "" },
+  { "cluster": "96c55abf-db62-4e99-b01a-9331a757097f", "cluster_name": "" },
+  { "cluster": "dd2ef343-9131-46f5-8962-290fdfdf2199", "cluster_name": "" },
+  { "cluster": "90f9a6ea-f79a-4d8d-a889-f0fb151aca5e", "cluster_name": "" },
+  { "cluster": "ff41a4ee-aa2c-43a2-ac65-d5956252416d", "cluster_name": "" },
+  { "cluster": "020cc0a1-6f1a-45fa-9780-3f4e74590902", "cluster_name": "" },
+  { "cluster": "75400997-78fe-404e-a900-1c630bc3501d", "cluster_name": "" }
 ]

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter/conditionalFilterConstants';
 import PrimaryToolbar from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
@@ -23,11 +26,11 @@ import {
   NoMatchingClusters,
 } from '../MessageState/EmptyStates';
 import Loading from '../Loading/Loading';
-import { Link } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
 import { updateAffectedClustersFilters } from '../../Services/Filters';
+import messages from '../../Messages';
 
 const AffectedClustersTable = ({ query }) => {
+  const intl = useIntl();
   const {
     isError,
     isUninitialized,
@@ -156,52 +159,54 @@ const AffectedClustersTable = ({ query }) => {
               }
         }
       />
-      {(isUninitialized || isFetching) && <Loading />}
-      {isError && (
-        <Card id="error-state-message">
-          <CardBody>
-            <ErrorState />
-          </CardBody>
-        </Card>
-      )}
-      {isSuccess && rows.length === 0 && (
-        <Card id="empty-state-message">
-          <CardBody>
-            <NoAffectedClusters />
-          </CardBody>
-        </Card>
-      )}
-      {isSuccess &&
-        rows.length > 0 &&
-        (filteredRows.length > 0 ? (
-          <Table
-            aria-label="Table of affected clusters"
-            ouiaId="affectedClustersTable"
-            variant="compact"
-            cells={[{ title: 'Name', transforms: [sortable] }]}
-            rows={displayedRows.map((c) => ({
-              cells: [
-                <span key={c?.cluter}>
-                  <Link to={`/clusters/${c?.cluster}`}>{c?.cluster}</Link>
-                </span>,
-              ],
-            }))}
-            sortBy={{
-              index: filters.sortIndex,
-              direction: filters.sortDirection,
-            }}
-            onSort={onSort}
-          >
-            <TableHeader />
+      <Table
+        aria-label="Table of affected clusters"
+        ouiaId="affectedClustersTable"
+        variant="compact"
+        cells={[
+          { title: intl.formatMessage(messages.name), transforms: [sortable] },
+        ]}
+        rows={displayedRows.map((c) => ({
+          cells: [
+            <span key={c?.cluter}>
+              <Link to={`/clusters/${c?.cluster}`}>{c?.cluster}</Link>
+            </span>,
+          ],
+        }))}
+        sortBy={{
+          index: filters.sortIndex,
+          direction: filters.sortDirection,
+        }}
+        onSort={onSort}
+      >
+        <TableHeader />
+        {(isUninitialized || isFetching) && <Loading />}
+        {isError && (
+          <Card id="error-state-message">
+            <CardBody>
+              <ErrorState />
+            </CardBody>
+          </Card>
+        )}
+        {isSuccess && rows.length === 0 && (
+          <Card id="empty-state-message">
+            <CardBody>
+              <NoAffectedClusters />
+            </CardBody>
+          </Card>
+        )}
+        {isSuccess &&
+          rows.length > 0 &&
+          (filteredRows.length > 0 ? (
             <TableBody />
-          </Table>
-        ) : (
-          <EmptyTable>
-            <Bullseye>
-              <NoMatchingClusters />
-            </Bullseye>
-          </EmptyTable>
-        ))}
+          ) : (
+            <EmptyTable>
+              <Bullseye>
+                <NoMatchingClusters />
+              </Bullseye>
+            </EmptyTable>
+          ))}
+      </Table>
       <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
         <Pagination
           variant={PaginationVariant.bottom}

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -169,7 +169,9 @@ const AffectedClustersTable = ({ query }) => {
         rows={displayedRows.map((c) => ({
           cells: [
             <span key={c?.cluter}>
-              <Link to={`/clusters/${c?.cluster}`}>{c?.cluster}</Link>
+              <Link to={`/clusters/${c?.cluster}`}>
+                {c?.cluster_name || c?.cluster}
+              </Link>
             </span>,
           ],
         }))}

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -76,6 +76,10 @@ describe('non-empty successful affected clusters table', () => {
     // three matched clusters rendered
     cy.countRows(3);
   });
+
+  it('renders table header', () => {
+    cy.get(AFFECTED_LIST_TABLE).find('th').should('have.text', 'Name');
+  });
 });
 
 describe('empty successful affected clusters table', () => {
@@ -109,6 +113,10 @@ describe('empty successful affected clusters table', () => {
       .find('h4')
       .should('have.text', 'No clusters');
   });
+
+  it('renders table header', () => {
+    cy.get(AFFECTED_LIST_TABLE).find('th').should('have.text', 'Name');
+  });
 });
 
 describe('empty failed affected clusters table', () => {
@@ -141,5 +149,9 @@ describe('empty failed affected clusters table', () => {
     cy.get('#error-state-message')
       .find('h4')
       .should('have.text', 'Something went wrong');
+  });
+
+  it('renders table header', () => {
+    cy.get(AFFECTED_LIST_TABLE).find('th').should('have.text', 'Name');
   });
 });

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -77,6 +77,14 @@ describe('non-empty successful affected clusters table', () => {
     cy.countRows(3);
   });
 
+  it('display name is rendered instead of cluster uuid', () => {
+    cy.get(AFFECTED_LIST_TABLE)
+      .find(ROW_GROUP)
+      .contains('custom cluster name 2')
+      .should('have.attr', 'href')
+      .and('contain', '/clusters/f7331e9a-2f59-484d-af52-338d56165df5');
+  });
+
   it('renders table header', () => {
     cy.get(AFFECTED_LIST_TABLE).find('th').should('have.text', 'Name');
   });

--- a/src/Components/ClustersList/index.js
+++ b/src/Components/ClustersList/index.js
@@ -11,6 +11,9 @@ import ClustersListTable from '../ClustersListTable';
 
 const ClustersList = () => {
   const intl = useIntl();
+  document.title = intl.formatMessage(messages.documentTitle, {
+    subnav: 'Clusters',
+  });
 
   return (
     <React.Fragment>

--- a/src/Components/Recommendation/index.js
+++ b/src/Components/Recommendation/index.js
@@ -1,14 +1,20 @@
 import React, { useEffect } from 'react';
-
 import { useParams, useRouteMatch } from 'react-router-dom';
+import { useIntl } from 'react-intl';
 
 import { Recommendation } from './Recommendation';
 import { useGetRuleByIdQuery } from '../../Services/SmartProxy';
 import { useGetRecAcksQuery } from '../../Services/Acks';
+import messages from '../../Messages';
 
 const RecommendationWrapper = () => {
+  const intl = useIntl();
   const rule = useGetRuleByIdQuery(useParams().recommendationId);
   const ack = useGetRecAcksQuery({ ruleId: useParams().recommendationId });
+  if (rule.isSuccess && rule.data?.content?.description) {
+    const subnav = `${rule.data.content.description} - Recommendations`;
+    document.title = intl.formatMessage(messages.documentTitle, { subnav });
+  }
 
   useEffect(() => {
     rule.refetch();

--- a/src/Components/RecsList/index.js
+++ b/src/Components/RecsList/index.js
@@ -15,6 +15,10 @@ const RecsListTable = lazy(() =>
 
 const RecsList = () => {
   const intl = useIntl();
+  document.title = intl.formatMessage(messages.documentTitle, {
+    subnav: 'Recommendations',
+  });
+
   return (
     <React.Fragment>
       <PageHeader className="ins-c-recommendations-header">


### PR DESCRIPTION
- [x] Rename document titles for the recommendations list, single recommendation, clusters list pages.
- [x] Render cluster display name, if available, instead of cluster UUID in the affected clusters table.
- [x] Always show header for the affected clusters table.