### PR TITLE
Hide disabled rules for single cluster page

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -162,9 +162,6 @@ export const FILTER_CATEGORIES = {
     ],
   },
 };
-export const DEFAULT_CLUSTER_RULES_FILTERS = {
-  [FILTER_CATEGORIES.rule_status.urlParam]: 'enabled',
-};
 export const TOTAL_RISK_LABEL_LOWER = {
   1: intlHelper(intl.formatMessage(messages.low).toLowerCase(), intlSettings),
   2: intlHelper(

--- a/src/Components/Cluster/index.js
+++ b/src/Components/Cluster/index.js
@@ -9,7 +9,10 @@ import { useGetClusterDisplayNameByIdQuery } from '../../Services/AccountManagem
 
 export default routerParams(({ match }) => {
   const intl = useIntl();
-  const cluster = useGetClusterByIdQuery(match.params.clusterId);
+  const cluster = useGetClusterByIdQuery({
+    id: match.params.clusterId,
+    includeDisabled: false,
+  });
   const displayName = useGetClusterDisplayNameByIdQuery(match.params.clusterId);
 
   useEffect(() => {

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -185,7 +185,7 @@ const ClusterRules = ({ reports }) => {
               created_at: rule.created_at,
               total_risk: rule.total_risk,
               category: rule.tags,
-              rule_status: rule.disabled ? 'disabled' : 'enabled',
+              rule_status: 'enabled',
             };
             if (key === 'category') {
               // in that case, rowValue['category'] is an array of categories (or "tags" in the back-end implementation)
@@ -261,12 +261,6 @@ const ClusterRules = ({ reports }) => {
     setFilters(newFilters);
   };
 
-  const toggleRulesDisabled = (rule_status) => {
-    const newFilters = { ...filters, rule_status };
-    setRows(buildRows(activeReports, newFilters, rows, searchValue));
-    setFilters(newFilters);
-  };
-
   const filterConfigItems = [
     {
       label: 'description',
@@ -299,18 +293,6 @@ const ClusterRules = ({ reports }) => {
         onChange: (_e, values) => onFilterChange(FC.category.urlParam, values),
         value: filters.category,
         items: FC.category.values,
-      },
-    },
-    {
-      label: FC.rule_status.title,
-      type: FC.rule_status.type,
-      id: FC.rule_status.urlParam,
-      value: `radio-${FC.rule_status.urlParam}`,
-      filterValues: {
-        key: `${FC.rule_status.urlParam}-filter`,
-        onChange: (_e, value) => toggleRulesDisabled(value),
-        value: filters.rule_status,
-        items: FC.rule_status.values,
       },
     },
   ];

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -31,7 +31,6 @@ import {
   LIKELIHOOD_LABEL,
   FILTER_CATEGORIES as FC,
   RULE_CATEGORIES,
-  DEFAULT_CLUSTER_RULES_FILTERS,
 } from '../../AppConstants';
 import ReportDetails from '../ReportDetails/ReportDetails';
 import RuleLabels from '../Labels/RuleLabels';
@@ -41,7 +40,7 @@ const ClusterRules = ({ reports }) => {
   const intl = useIntl();
   const [activeReports, setActiveReports] = useState([]);
   const [sortBy, setSortBy] = useState({});
-  const [filters, setFilters] = useState(DEFAULT_CLUSTER_RULES_FILTERS);
+  const [filters, setFilters] = useState({});
   const [searchValue, setSearchValue] = useState('');
   const [rows, setRows] = useState([]);
   const results = rows ? rows.length / 2 : 0;
@@ -185,7 +184,6 @@ const ClusterRules = ({ reports }) => {
               created_at: rule.created_at,
               total_risk: rule.total_risk,
               category: rule.tags,
-              rule_status: 'enabled',
             };
             if (key === 'category') {
               // in that case, rowValue['category'] is an array of categories (or "tags" in the back-end implementation)
@@ -193,9 +191,6 @@ const ClusterRules = ({ reports }) => {
               return rowValue[key].find((categoryName) =>
                 filterValues.includes(String(RULE_CATEGORIES[categoryName]))
               );
-            }
-            if (key === 'rule_status') {
-              return filterValues === 'all' || rowValue[key] === filterValues;
             }
             return filterValues.find(
               (value) => String(value) === String(rowValue[key])
@@ -335,10 +330,8 @@ const ClusterRules = ({ reports }) => {
 
   const onChipDelete = (_e, itemsToRemove, isAll) => {
     if (isAll) {
-      setRows(
-        buildRows(activeReports, DEFAULT_CLUSTER_RULES_FILTERS, rows, '')
-      );
-      setFilters(DEFAULT_CLUSTER_RULES_FILTERS);
+      setRows(buildRows(activeReports, {}, rows, ''));
+      setFilters({});
       setSearchValue('');
     } else {
       itemsToRemove.map((item) => {
@@ -346,9 +339,6 @@ const ClusterRules = ({ reports }) => {
           case 'Description':
             setRows(buildRows(activeReports, filters, rows, ''));
             setSearchValue('');
-            break;
-          case 'Status':
-            onFilterChange(item.urlParam, []);
             break;
           default:
             onFilterChange(

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -9,7 +9,7 @@ export const SmartProxyApi = createApi({
   }),
   endpoints: (builder) => ({
     getClusterById: builder.query({
-      query: (id, includeDisabled = true) =>
+      query: ({ id, includeDisabled }) =>
         `v2/cluster/${id}/reports?get_disabled=${includeDisabled}`,
     }),
     // Get rule's content using id (recId = recommendation id) in the rule_plugin_name|error_key format


### PR DESCRIPTION
Rewrote API query so we'll request only enabled rules for single cluster page

Removed unnecessary code related to the "status" of the rules on the single cluster page