### PR TITLE
Added collapse/expand all button to the single cluster page

### DIFF
--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -43,6 +43,7 @@ const ClusterRules = ({ reports }) => {
   const [filters, setFilters] = useState({});
   const [searchValue, setSearchValue] = useState('');
   const [rows, setRows] = useState([]);
+  const [isAllExpanded, setIsAllExpanded] = useState(false);
   const results = rows ? rows.length / 2 : 0;
 
   const cols = [
@@ -65,31 +66,6 @@ const ClusterRules = ({ reports }) => {
     collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
     setRows(collapseRows);
   };
-
-  const onKebabClick = (action) => {
-    const isOpen = action === 'insights-expand-all';
-    const allRows = [...rows];
-
-    allRows.map((row, key) => {
-      if (Object.prototype.hasOwnProperty.call(row, 'isOpen')) {
-        row.isOpen = isOpen;
-        isOpen && handleOnCollapse(null, key, isOpen);
-      }
-    });
-
-    setRows(allRows);
-  };
-
-  const actions = [
-    {
-      label: 'Collapse all',
-      onClick: () => onKebabClick('insights-collapse-all'),
-    },
-    {
-      label: 'Expand all',
-      onClick: () => onKebabClick('insights-expand-all'),
-    },
-  ];
 
   const buildRows = (activeReports, filters, rows, searchValue = '') => {
     const builtRows = activeReports.flatMap((value, key) => {
@@ -358,6 +334,19 @@ const ClusterRules = ({ reports }) => {
     onDelete: onChipDelete,
   };
 
+  const onExpandAllClick = (_e, isOpen) => {
+    setIsAllExpanded(isOpen);
+    const allRows = [...rows];
+
+    allRows.map((row) => {
+      if (Object.prototype.hasOwnProperty.call(row, 'isOpen')) {
+        row.isOpen = isOpen;
+      }
+    });
+
+    setRows(allRows);
+  };
+
   useEffect(() => {
     const activeReportsData = reports;
     setActiveReports(activeReportsData);
@@ -367,7 +356,7 @@ const ClusterRules = ({ reports }) => {
   return (
     <div id="cluster-recs-list-table">
       <PrimaryToolbar
-        actionsConfig={{ actions }}
+        expandAll={{ isAllExpanded, onClick: onExpandAllClick }}
         filterConfig={{
           items: filterConfigItems,
           isDisabled: activeReports.length === 0,

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -54,21 +54,13 @@ describe('cluster rules table', () => {
   it('first item expanded', () => {
     cy.get('#expanded-content1').should('have.length', 1);
   });
-
   it('expand all, collapse all', () => {
-    const TOOLBAR =
-      '[class="pf-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"]';
+    const TOOLBAR = '[class="pf-c-toolbar__item"]';
     const EXPANDABLES = '[class="pf-c-table__expandable-row pf-m-expanded"]';
 
     cy.get(TOOLBAR).find('button').click();
-    cy.get('.pf-c-dropdown__menu-item')
-      .contains('Expand all')
-      .click({ force: true });
     cy.get(EXPANDABLES).should('have.length', 6);
     cy.get(TOOLBAR).find('button').click();
-    cy.get('.ins-c-primary-toolbar__first-action')
-      .find('button')
-      .click({ force: true });
     cy.get(EXPANDABLES).should('have.length', 0);
   });
 


### PR DESCRIPTION
The first look when a user opens the page
![image](https://user-images.githubusercontent.com/62722417/147970075-4a390119-b58c-4e9b-a3d0-1dadfb033122.png)After the user clicked on the Expand/Collapse button
![image](https://user-images.githubusercontent.com/62722417/147970107-f7ce6a4a-f928-4c96-91d2-0e17a9597ab9.png)After the user clicked on the Expand/Collapse button again
![image](https://user-images.githubusercontent.com/62722417/147970143-a69c5865-9bf4-4d36-8147-e2bc16249e54.png)