### PR TITLE
Update params that are passed to the RuleDetails federated module

### DIFF
--- a/src/Components/Recommendation/RuleDetails.js
+++ b/src/Components/Recommendation/RuleDetails.js
@@ -1,21 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useIntl } from 'react-intl';
+import { useHistory } from 'react-router-dom';
 
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
 import Loading from '../Loading/Loading';
+import messages from '../../Messages';
+import { translations } from '../../Utilities/intlHelper';
 
-const RuleDetails = ({
-  rule,
-  header,
-  isDetailsPage,
-  resolutionRisk,
-  riskOfChangeDesc,
-  onFeedbackChanged,
-  children,
-}) => {
-  const intl = useIntl();
+const RuleDetails = ({ children, ...props }) => {
+  // make sure history@4.x.x is used as a react-router-dom dependency
+  const history = useHistory();
 
   return (
     <div className="advisor">
@@ -23,15 +18,11 @@ const RuleDetails = ({
         appName="advisor"
         module="./AdvisorRecommendationDetails"
         fallback={<Loading />}
-        rule={rule}
-        customItnl
-        intlProps={intl}
-        isDetailsPage={isDetailsPage}
-        header={header}
-        resolutionRisk={resolutionRisk}
         isOpenShift
-        riskOfChangeDesc={riskOfChangeDesc}
-        onFeedbackChanged={onFeedbackChanged}
+        intlProps={{ messages: translations[navigator.language.slice(0, 2)] }}
+        history={history}
+        messageDescriptors={messages}
+        {...props}
       >
         {children}
       </AsyncComponent>

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -167,8 +167,6 @@ const RecsListTable = ({ query }) => {
                       rule={{
                         ...value,
                         impact: { impact: value.impact },
-                        // TODO: fix <Router> issue in the async component and then remove the line below
-                        impacted_clusters_count: undefined,
                       }}
                       isDetailsPage={false}
                     />

--- a/src/Utilities/intlHelper.js
+++ b/src/Utilities/intlHelper.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations/';
 
-const translations = {
+export const translations = {
   en: require('../../compiled-lang/en.json'),
 };
 


### PR DESCRIPTION
- [x] Fix `impacted_clusters_number` value that was intentionally set to undefined and not propagated to the RuleDetails federated module.
- [x] Pass the `history` object to RuleDetails from the RHEL Advisor so that a custom Router wrapper can be used (relates to https://github.com/RedHatInsights/insights-advisor-frontend/pull/891)