### PR TITLE
Fixed a bug with the clusters Impacted filter and status All

### DIFF
--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -237,7 +237,6 @@ const RecsListTable = ({ query }) => {
         ...filters,
         rule_status,
         offset: 0,
-        ...(rule_status !== 'enabled' && { impacting: ['false'] }),
       })
     );
   };

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -12,6 +12,8 @@ import { Intl } from '../../Utilities/intlHelper';
 const RECS_LIST_TABLE = 'div[id=recs-list-table]';
 const CHIP = 'div[class=pf-c-chip]';
 const ROW = 'tbody[role=rowgroup]';
+const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
+const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
 
 // actions
 Cypress.Commands.add('getAllRows', () => cy.get(RECS_LIST_TABLE).find(ROW));
@@ -284,10 +286,6 @@ describe('successful non-empty recommendations list table', () => {
   });
 
   it('the Impacted filters work correctly', () => {
-    const RECS_LIST_TABLE = 'div[id=recs-list-table]';
-    const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
-    const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
-
     cy.get(RECS_LIST_TABLE).find('button[class=pf-c-dropdown__toggle]').click();
     cy.get(FILTERS_DROPDOWN)
       .contains('Clusters impacted')
@@ -299,8 +297,7 @@ describe('successful non-empty recommendations list table', () => {
       cy.wrap(element);
       element[0].click();
     });
-    cy.get('#pf-random-id-72-false').check({ force: true });
-    cy.get('.pf-c-chip-group__list-item').contains('1 or more');
+    cy.get('.pf-c-check__input').check({ force: true });
 
     cy.get(RECS_LIST_TABLE).find('button[class=pf-c-dropdown__toggle]').click();
     cy.get(FILTERS_DROPDOWN)

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -282,6 +282,26 @@ describe('successful non-empty recommendations list table', () => {
       .find('td[data-label=Category]')
       .should('contain', 'Service Availability');
   });
+
+  it('the filters work correctly', () => {
+    const RECS_LIST_TABLE = 'div[id=recs-list-table]';
+    const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
+    const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
+
+    cy.get(RECS_LIST_TABLE).find('button[class=pf-c-dropdown__toggle]').click();
+    cy.get(FILTERS_DROPDOWN)
+      .contains('Clusters impacted')
+      .then((element) => {
+        cy.wrap(element);
+        element[0].click();
+      });
+    cy.get(FILTER_TOGGLE).then((element) => {
+      cy.wrap(element);
+      element[0].click();
+    });
+    cy.get('#pf-random-id-72-false').check({ force: true });
+    cy.get('.pf-c-chip-group__list-item').contains('1 or more');
+  });
 });
 
 describe('empty recommendations list table', () => {

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -14,7 +14,6 @@ const CHIP = 'div[class=pf-c-chip]';
 const ROW = 'tbody[role=rowgroup]';
 const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
 const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
-
 // actions
 Cypress.Commands.add('getAllRows', () => cy.get(RECS_LIST_TABLE).find(ROW));
 Cypress.Commands.add('removeStatusFilter', () => {
@@ -286,10 +285,6 @@ describe('successful non-empty recommendations list table', () => {
   });
 
   it('the Impacted filters work correctly', () => {
-    const RECS_LIST_TABLE = 'div[id=recs-list-table]';
-    const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
-    const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
-
     cy.get(RECS_LIST_TABLE)
       .find('button[class=pf-c-dropdown__toggle]')
       .click({ force: true });

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -283,7 +283,7 @@ describe('successful non-empty recommendations list table', () => {
       .should('contain', 'Service Availability');
   });
 
-  it('the filters work correctly', () => {
+  it('the Impacted filters work correctly', () => {
     const RECS_LIST_TABLE = 'div[id=recs-list-table]';
     const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
     const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
@@ -300,6 +300,25 @@ describe('successful non-empty recommendations list table', () => {
       element[0].click();
     });
     cy.get('#pf-random-id-72-false').check({ force: true });
+    cy.get('.pf-c-chip-group__list-item').contains('1 or more');
+
+    cy.get(RECS_LIST_TABLE).find('button[class=pf-c-dropdown__toggle]').click();
+    cy.get(FILTERS_DROPDOWN)
+      .contains('Status')
+      .then((element) => {
+        cy.wrap(element);
+        element[0].click();
+      });
+    cy.get(FILTER_TOGGLE).then((element) => {
+      cy.wrap(element);
+      element[0].click();
+    });
+    cy.get('button[class=pf-c-select__menu-item]')
+      .contains('All')
+      .then((element) => {
+        cy.wrap(element);
+        element[0].click();
+      });
     cy.get('.pf-c-chip-group__list-item').contains('1 or more');
   });
 });

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -286,36 +286,34 @@ describe('successful non-empty recommendations list table', () => {
   });
 
   it('the Impacted filters work correctly', () => {
-    cy.get(RECS_LIST_TABLE).find('button[class=pf-c-dropdown__toggle]').click();
+    const RECS_LIST_TABLE = 'div[id=recs-list-table]';
+    const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
+    const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
+
+    cy.get(RECS_LIST_TABLE)
+      .find('button[class=pf-c-dropdown__toggle]')
+      .click({ force: true });
     cy.get(FILTERS_DROPDOWN)
       .contains('Clusters impacted')
-      .then((element) => {
-        cy.wrap(element);
-        element[0].click();
-      });
+      .click({ force: true });
     cy.get(FILTER_TOGGLE).then((element) => {
       cy.wrap(element);
-      element[0].click();
+      element[0].click({ force: true });
     });
-    cy.get('.pf-c-check__input').check({ force: true });
+    cy.get('.pf-c-select__menu')
+      .find('label > input')
+      .eq(1)
+      .check({ force: true });
+    cy.get('.pf-c-chip-group__list-item').contains('1 or more');
 
-    cy.get(RECS_LIST_TABLE).find('button[class=pf-c-dropdown__toggle]').click();
-    cy.get(FILTERS_DROPDOWN)
-      .contains('Status')
-      .then((element) => {
-        cy.wrap(element);
-        element[0].click();
-      });
-    cy.get(FILTER_TOGGLE).then((element) => {
-      cy.wrap(element);
-      element[0].click();
-    });
+    cy.get(RECS_LIST_TABLE)
+      .find('button[class=pf-c-dropdown__toggle]')
+      .click({ force: true });
+    cy.get(FILTERS_DROPDOWN).contains('Status').click({ force: true });
+    cy.get(FILTER_TOGGLE).click({ force: true });
     cy.get('button[class=pf-c-select__menu-item]')
       .contains('All')
-      .then((element) => {
-        cy.wrap(element);
-        element[0].click();
-      });
+      .click({ force: true });
     cy.get('.pf-c-chip-group__list-item').contains('1 or more');
   });
 });


### PR DESCRIPTION
There was a bug with filters
After debugging and discussing it with Georgy he advised to remove this line of code, it was a culprit causing this bug.
1. Navigate to the recommendations page
2. Open the filter "Cluster impacted" and leave the "1 or more" selected and then select the "None" (so both are selected)
3. Open the filter status and select "All"

The "1 or more" filter for "Cluster impacted" is removed from the list of filters.