### PR TITLE
Synchronize table filters, offset and limit with URL query parameters (1/2)

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -254,3 +254,22 @@ export const RECS_LIST_COLUMNS_KEYS = [
   'impacted_clusters_count',
 ];
 export const DEBOUNCE_DELAY = 600;
+export const CLUSTER_RULES_COLUMNS_KEYS = [
+  'description',
+  'created_at',
+  'total_risk',
+];
+export const CLUSTER_RULES_COLUMNS = [
+  {
+    title: intl.formatMessage(messages.description),
+    transforms: [sortable],
+  },
+  {
+    title: intl.formatMessage(messages.added),
+    transforms: [sortable, cellWidth(15)],
+  },
+  {
+    title: intl.formatMessage(messages.totalRisk),
+    transforms: [sortable, cellWidth(15)],
+  },
+];

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -246,3 +246,10 @@ export const CLUSTERS_LIST_COLUMNS = [
 ];
 export const CLUSTER_NAME_CELL = 0;
 export const CLUSTER_LAST_CHECKED_CELL = 6;
+export const RECS_LIST_COLUMNS_KEYS = [
+  'description',
+  'publish_date',
+  'tags',
+  'total_risk',
+  'impacted_clusters_count',
+];

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -253,3 +253,4 @@ export const RECS_LIST_COLUMNS_KEYS = [
   'total_risk',
   'impacted_clusters_count',
 ];
+export const DEBOUNCE_DELAY = 600;

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -3,6 +3,7 @@ import './_ClusterRules.scss';
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import capitalize from 'lodash/capitalize';
 
 import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat/DateFormat';
@@ -16,7 +17,6 @@ import {
   cellWidth,
   sortable,
 } from '@patternfly/react-table';
-import { capitalize } from '@patternfly/react-core/dist/js/helpers/util';
 import { Card, CardBody } from '@patternfly/react-core/dist/js/components/Card';
 import {
   Tooltip,

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -3,6 +3,8 @@ import './_ClusterRules.scss';
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import { useLocation } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import capitalize from 'lodash/capitalize';
 
 import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
@@ -14,8 +16,6 @@ import {
   TableBody,
   TableHeader,
   TableVariant,
-  cellWidth,
-  sortable,
 } from '@patternfly/react-table';
 import { Card, CardBody } from '@patternfly/react-core/dist/js/components/Card';
 import {
@@ -30,69 +30,85 @@ import {
   IMPACT_LABEL,
   LIKELIHOOD_LABEL,
   FILTER_CATEGORIES as FC,
-  RULE_CATEGORIES,
+  CLUSTER_RULES_COLUMNS_KEYS,
+  FILTER_CATEGORIES,
+  CLUSTER_RULES_COLUMNS,
 } from '../../AppConstants';
 import ReportDetails from '../ReportDetails/ReportDetails';
 import RuleLabels from '../Labels/RuleLabels';
 import { NoMatchingRecs } from '../MessageState/EmptyStates';
+import {
+  paramParser,
+  passFilters,
+  translateSortParams,
+} from '../Common/Tables';
+import {
+  CLUSTER_RULES_INITIAL_STATE,
+  updateClusterRulesFilters,
+} from '../../Services/Filters';
 
 const ClusterRules = ({ reports }) => {
   const intl = useIntl();
-  const [activeReports, setActiveReports] = useState([]);
-  const [sortBy, setSortBy] = useState({});
-  const [filters, setFilters] = useState({});
-  const [searchValue, setSearchValue] = useState('');
-  const [rows, setRows] = useState([]);
-  const [isAllExpanded, setIsAllExpanded] = useState(false);
-  const results = rows ? rows.length / 2 : 0;
+  const dispatch = useDispatch();
+  const updateFilters = (filters) =>
+    dispatch(updateClusterRulesFilters(filters));
+  const filters = useSelector(({ filters }) => filters.clusterRulesState);
 
-  const cols = [
-    {
-      title: intl.formatMessage(messages.description),
-      transforms: [sortable],
-    },
-    {
-      title: intl.formatMessage(messages.added),
-      transforms: [sortable, cellWidth(15)],
-    },
-    {
-      title: intl.formatMessage(messages.totalRisk),
-      transforms: [sortable, cellWidth(15)],
-    },
-  ];
+  const [filteredRows, setFilteredRows] = useState([]);
+  const [displayedRows, setDisplayedRows] = useState([]);
+  const [isAllExpanded, setIsAllExpanded] = useState(false);
+  const results = filteredRows.length;
+  const { search } = useLocation();
+
+  useEffect(() => {
+    setDisplayedRows(
+      buildDisplayedRows(filteredRows, filters.sortIndex, filters.sortDirection)
+    );
+  }, [
+    filteredRows,
+    filters.limit,
+    filters.offset,
+    filters.sortIndex,
+    filters.sortDirection,
+  ]);
+
+  useEffect(() => {
+    setFilteredRows(buildFilteredRows(reports, filters));
+  }, [reports, filters]);
+
+  useEffect(() => {
+    if (search) {
+      const paramsObject = paramParser(search);
+      if (paramsObject.sort) {
+        const sortObj = translateSortParams(paramsObject.sort[0]);
+        paramsObject.sortIndex = CLUSTER_RULES_COLUMNS_KEYS.indexOf(
+          sortObj.name
+        );
+        paramsObject.sortDirection = sortObj.direction;
+      }
+      updateFilters({ ...filters, ...paramsObject });
+    }
+  }, []);
 
   const handleOnCollapse = (_e, rowId, isOpen) => {
-    const collapseRows = [...rows];
+    const collapseRows = [...displayedRows];
     collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
-    setRows(collapseRows);
+    setDisplayedRows(collapseRows);
   };
 
-  const buildRows = (activeReports, filters, rows, searchValue = '') => {
-    const builtRows = activeReports.flatMap((value, key) => {
-      const rule = value;
-      const resolution = value.resolution;
-      const entity = rows.filter(
-        (rowVal, rowKey) =>
-          rowKey % 2 === 0 && rowVal.rule.rule_id === rule.rule_id && rowVal
-      );
-      const isOpen = rows.length
-        ? entity.length
-          ? entity[0].isOpen
-          : false
-        : key === 0
-        ? true
-        : false;
-
-      const reportRow = [
+  const buildFilteredRows = (allRows, filters) =>
+    allRows
+      .filter((rule) => passFilters(rule, filters))
+      .map((value, key) => [
         {
-          rule,
-          resolution,
-          isOpen,
+          rule: value,
+          isOpen: isAllExpanded,
           cells: [
             {
               title: (
                 <div>
-                  {rule.description} <RuleLabels rule={value} />
+                  {value?.description || value?.rule_id}{' '}
+                  <RuleLabels rule={value} />
                 </div>
               ),
             },
@@ -100,7 +116,7 @@ const ClusterRules = ({ reports }) => {
               title: (
                 <div key={key}>
                   <DateFormat
-                    date={rule.created_at}
+                    date={value.created_at}
                     type="relative"
                     tooltipProps={{ position: TooltipPosition.bottom }}
                   />
@@ -110,7 +126,7 @@ const ClusterRules = ({ reports }) => {
             {
               title: (
                 <div key={key} style={{ verticalAlign: 'top' }}>
-                  {rule?.likelihood && rule?.impact ? (
+                  {value?.likelihood && value?.impact ? (
                     <Tooltip
                       key={key}
                       position={TooltipPosition.bottom}
@@ -119,19 +135,21 @@ const ClusterRules = ({ reports }) => {
                         <span>
                           The <strong>likelihood</strong> that this will be a
                           problem is{' '}
-                          {rule.likelihood
-                            ? LIKELIHOOD_LABEL[rule.likelihood]
+                          {value.likelihood
+                            ? LIKELIHOOD_LABEL[value.likelihood]
                             : 'unknown'}
-                          . The <strong>impact</strong> of the problem would be{' '}
-                          {rule.impact ? IMPACT_LABEL[rule.impact] : 'unknown'}{' '}
+                          .The <strong>impact</strong> of the problem would be{' '}
+                          {value.impact
+                            ? IMPACT_LABEL[value.impact]
+                            : 'unknown'}{' '}
                           if it occurred.
                         </span>
                       }
                     >
-                      <InsightsLabel value={rule.total_risk} />
+                      <InsightsLabel value={value.total_risk} />
                     </Tooltip>
                   ) : (
-                    <InsightsLabel value={rule.total_risk} />
+                    <InsightsLabel value={value.total_risk} />
                   )}
                 </div>
               ),
@@ -139,7 +157,6 @@ const ClusterRules = ({ reports }) => {
           ],
         },
         {
-          parent: key,
           fullWidth: true,
           cells: [
             {
@@ -147,98 +164,46 @@ const ClusterRules = ({ reports }) => {
             },
           ],
         },
-      ];
-      const isValidSearchValue =
-        searchValue.length === 0 ||
-        rule.description.toLowerCase().includes(searchValue.toLowerCase());
-      const isValidFilterValue =
-        Object.keys(filters).length === 0 ||
-        Object.keys(filters)
-          .map((key) => {
-            const filterValues = filters[key];
-            const rowValue = {
-              created_at: rule.created_at,
-              total_risk: rule.total_risk,
-              category: rule.tags,
-            };
-            if (key === 'category') {
-              // in that case, rowValue['category'] is an array of categories (or "tags" in the back-end implementation)
-              // e.g. ['security', 'fault_tolerance']
-              return rowValue[key].find((categoryName) =>
-                filterValues.includes(String(RULE_CATEGORIES[categoryName]))
-              );
-            }
-            return filterValues.find(
-              (value) => String(value) === String(rowValue[key])
-            );
-          })
-          .every((x) => x);
+      ]);
 
-      return isValidSearchValue && isValidFilterValue ? reportRow : [];
+  const buildDisplayedRows = (rows, index, direction) => {
+    const sortingRows = [...rows].sort((firstItem, secondItem) => {
+      const fst = firstItem[0].rule[CLUSTER_RULES_COLUMNS_KEYS[index - 1]];
+      const snd = secondItem[0].rule[CLUSTER_RULES_COLUMNS_KEYS[index - 1]];
+      return fst > snd ? 1 : snd > fst ? -1 : 0;
     });
-    // must recalculate parent for expandable table content whenever the array size changes
-    builtRows.forEach((row, index) =>
-      row.parent ? (row.parent = index - 1) : null
-    );
-
-    return builtRows;
-  };
-
-  const onSort = (_e, index, direction) => {
-    const sortedReports = {
-      1: 'description',
-      2: 'created_at',
-      3: 'total_risk',
-    };
-    const sort = () =>
-      activeReports
-        .concat()
-        .sort((firstItem, secondItem) =>
-          firstItem[sortedReports[index]] > secondItem[sortedReports[index]]
-            ? 1
-            : secondItem[sortedReports[index]] > firstItem[sortedReports[index]]
-            ? -1
-            : 0
-        );
-    const sortedReportsDirectional =
-      direction === SortByDirection.asc ? sort() : sort().reverse();
-
-    setActiveReports(sortedReportsDirectional);
-    setSortBy({
-      index,
-      direction,
+    if (direction === SortByDirection.desc) {
+      sortingRows.reverse();
+    }
+    return sortingRows.flatMap((row, index) => {
+      const updatedRow = [...row];
+      row[1].parent = index * 2;
+      return updatedRow;
     });
-    setRows(buildRows(sortedReportsDirectional, filters, rows, searchValue));
   };
 
-  const onInputChange = (value) => {
-    const builtRows = buildRows(activeReports, filters, rows, value);
-    setSearchValue(value);
-    setRows(builtRows);
+  const onSort = (_e, index, direction) =>
+    updateFilters({ ...filters, sortIndex: index, sortDirection: direction });
+
+  const removeFilterParam = (param) => {
+    const filter = { ...filters, offset: 0 };
+    delete filter[param];
+    updateFilters({ ...filter, ...(param === 'text' ? { text: '' } : {}) });
   };
 
-  const onFilterChange = (param, values) => {
-    const removeFilterParam = (param) => {
-      const filter = { ...filters };
-      delete filter[param];
-      return filter;
-    };
-
-    const newFilters =
-      values.length > 0
-        ? { ...filters, ...{ [param]: values } }
-        : removeFilterParam(param);
-    setRows(buildRows(activeReports, newFilters, rows, searchValue));
-    setFilters(newFilters);
-  };
+  // TODO: update URL when filters changed
+  const addFilterParam = (param, values) =>
+    values.length > 0
+      ? updateFilters({ ...filters, offset: 0, ...{ [param]: values } })
+      : removeFilterParam(param);
 
   const filterConfigItems = [
     {
       label: 'description',
       filterValues: {
         key: 'text-filter',
-        onChange: (_e, value) => onInputChange(value),
-        value: searchValue,
+        onChange: (_e, value) => addFilterParam('text', value),
+        value: filters.text,
       },
     },
     {
@@ -249,7 +214,7 @@ const ClusterRules = ({ reports }) => {
       filterValues: {
         key: `${FC.total_risk.urlParam}-filter`,
         onChange: (_e, values) =>
-          onFilterChange(FC.total_risk.urlParam, values),
+          addFilterParam(FILTER_CATEGORIES.total_risk.urlParam, values),
         value: filters.total_risk,
         items: FC.total_risk.values,
       },
@@ -261,26 +226,34 @@ const ClusterRules = ({ reports }) => {
       value: `checkbox-${FC.category.urlParam}`,
       filterValues: {
         key: `${FC.category.urlParam}-filter`,
-        onChange: (_e, values) => onFilterChange(FC.category.urlParam, values),
+        onChange: (_e, values) =>
+          addFilterParam(FILTER_CATEGORIES.category.urlParam, values),
         value: filters.category,
         items: FC.category.values,
       },
     },
   ];
 
-  const buildFilterChips = () => {
-    const prunedFilters = Object.entries(filters);
-    let chips =
-      filters && prunedFilters.length > 0
-        ? prunedFilters.map((item) => {
-            const category = FC[item[0]];
+  const pruneFilters = (localFilters, filterCategories) => {
+    const prunedFilters = Object.entries(localFilters);
+    return prunedFilters.length > 0
+      ? prunedFilters.reduce((arr, item) => {
+          if (filterCategories[item[0]]) {
+            const category = filterCategories[item[0]];
             const chips = Array.isArray(item[1])
-              ? item[1].map((value) => ({
-                  name: category.values.find(
+              ? item[1].map((value) => {
+                  const selectedCategoryValue = category.values.find(
                     (values) => values.value === String(value)
-                  ).label,
-                  value,
-                }))
+                  );
+                  return selectedCategoryValue
+                    ? {
+                        name:
+                          selectedCategoryValue.text ||
+                          selectedCategoryValue.label,
+                        value,
+                      }
+                    : { name: value, value };
+                })
               : [
                   {
                     name: category.values.find(
@@ -289,77 +262,87 @@ const ClusterRules = ({ reports }) => {
                     value: item[1],
                   },
                 ];
-            return {
-              category: capitalize(category.title),
-              chips,
-              urlParam: category.urlParam,
-            };
-          })
-        : [];
-    searchValue.length > 0 &&
-      chips.push({
-        category: 'Description',
-        chips: [{ name: searchValue, value: searchValue }],
-      });
-    return chips;
+            return [
+              ...arr,
+              {
+                category: capitalize(category.title),
+                chips,
+                urlParam: category.urlParam,
+              },
+            ];
+          } else if (item[0] === 'text') {
+            return [
+              ...arr,
+              ...(item[1].length > 0
+                ? [
+                    {
+                      category: 'Name',
+                      chips: [{ name: item[1], value: item[1] }],
+                      urlParam: item[0],
+                    },
+                  ]
+                : []),
+            ];
+          } else {
+            return arr;
+          }
+        }, [])
+      : [];
   };
 
-  const onChipDelete = (_e, itemsToRemove, isAll) => {
-    if (isAll) {
-      setRows(buildRows(activeReports, {}, rows, ''));
-      setFilters({});
-      setSearchValue('');
-    } else {
-      itemsToRemove.map((item) => {
-        switch (item.category) {
-          case 'Description':
-            setRows(buildRows(activeReports, filters, rows, ''));
-            setSearchValue('');
-            break;
-          default:
-            onFilterChange(
-              item.urlParam,
-              filters[item.urlParam].filter(
-                (value) => String(value) !== String(item.chips[0].value)
-              )
-            );
-        }
-      });
-    }
+  const buildFilterChips = () => {
+    const localFilters = { ...filters };
+    delete localFilters.sortIndex;
+    delete localFilters.sortDirection;
+    delete localFilters.offset;
+    delete localFilters.limit;
+    return pruneFilters(localFilters, FILTER_CATEGORIES);
   };
 
   const activeFiltersConfig = {
     deleteTitle: intl.formatMessage(messages.resetFilters),
     filters: buildFilterChips(),
-    onDelete: onChipDelete,
-  };
-
-  const onExpandAllClick = (_e, isOpen) => {
-    setIsAllExpanded(isOpen);
-    const allRows = [...rows];
-
-    allRows.map((row) => {
-      if (Object.prototype.hasOwnProperty.call(row, 'isOpen')) {
-        row.isOpen = isOpen;
+    onDelete: (_event, itemsToRemove, isAll) => {
+      if (isAll) {
+        updateFilters(CLUSTER_RULES_INITIAL_STATE);
+      } else {
+        itemsToRemove.map((item) => {
+          const newFilter = {
+            [item.urlParam]: Array.isArray(filters[item.urlParam])
+              ? filters[item.urlParam].filter(
+                  (value) => String(value) !== String(item.chips[0].value)
+                )
+              : '',
+          };
+          newFilter[item.urlParam].length > 0
+            ? updateFilters({ ...filters, ...newFilter })
+            : removeFilterParam(item.urlParam);
+        });
       }
-    });
-
-    setRows(allRows);
+    },
   };
 
-  useEffect(() => {
-    const activeReportsData = reports;
-    setActiveReports(activeReportsData);
-    setRows(buildRows(activeReportsData, filters, rows, searchValue));
-  }, []);
+  //Responsible for the handling collapse for all the recommendations
+  //Used in the PrimaryToolbar
+  const collapseAll = (_e, isOpen) => {
+    setIsAllExpanded(isOpen);
+    setDisplayedRows(
+      displayedRows.map((row) => {
+        return {
+          ...row,
+          isOpen: isOpen,
+        };
+      })
+    );
+  };
 
   return (
     <div id="cluster-recs-list-table">
       <PrimaryToolbar
-        expandAll={{ isAllExpanded, onClick: onExpandAllClick }}
+        expandAll={{ isAllExpanded, onClick: collapseAll }}
         filterConfig={{
           items: filterConfigItems,
-          isDisabled: activeReports.length === 0,
+          isDisabled: filteredRows.length === 0,
         }}
         pagination={
           <React.Fragment>
@@ -369,18 +352,21 @@ const ClusterRules = ({ reports }) => {
           </React.Fragment>
         }
         activeFiltersConfig={
-          activeReports.length === 0 ? undefined : activeFiltersConfig
+          filteredRows.length === 0 ? undefined : activeFiltersConfig
         }
       />
-      {activeReports.length > 0 ? (
+      {filteredRows.length > 0 ? (
         <React.Fragment>
           <Table
             aria-label={'Cluster recommendations table'}
             ouiaId="recommendations"
             onCollapse={handleOnCollapse}
-            rows={rows}
-            cells={cols}
-            sortBy={sortBy}
+            rows={displayedRows}
+            cells={CLUSTER_RULES_COLUMNS}
+            sortBy={{
+              index: filters.sortIndex,
+              direction: filters.sortDirection,
+            }}
             onSort={onSort}
             variant={TableVariant.compact}
             isStickyHeader

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -59,7 +59,7 @@ describe('clusters list table', () => {
   it('applies one total risk filter as a default', () => {
     cy.get(CHIP_GROUP)
       .find('.pf-c-chip-group__label')
-      .should('have.text', 'Total Risk');
+      .should('have.text', 'Total risk');
     cy.get(CHIP_GROUP)
       .find('.pf-c-chip__text')
       .should('have.length', 1)

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import capitalize from 'lodash/capitalize';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { Tooltip } from '@patternfly/react-core/dist/js/components/Tooltip';
@@ -111,10 +112,7 @@ export const mapClustersToRows = (clusters) =>
     ],
   }));
 
-export const capitalize = (string) =>
-  string[0].toUpperCase() + string.substring(1);
-
-export const pruneFilters = (localFilters, filterCategories) => {
+const pruneFilters = (localFilters, filterCategories) => {
   const prunedFilters = Object.entries(localFilters || {});
   return prunedFilters.reduce((arr, it) => {
     const [key, item] = it;

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -197,8 +197,8 @@ export const paramParser = (search) => {
 };
 
 export const translateSortParams = (value) => ({
-  sortValue: value.substring(value.startsWith('-') ? 1 : 0),
-  sortDirection: value.startsWith('-') ? 'desc' : 'asc',
+  name: value.substring(value.startsWith('-') ? 1 : 0),
+  direction: value.startsWith('-') ? 'desc' : 'asc',
 });
 
 export const debounce = (value, delay) => {

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { Tooltip } from '@patternfly/react-core/dist/js/components/Tooltip';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
@@ -13,7 +13,7 @@ import {
 } from '../../AppConstants';
 import messages from '../../Messages';
 
-const passFilters = (rule, filters) =>
+export const passFilters = (rule, filters) =>
   Object.entries(filters).every(([filterKey, filterValue]) => {
     switch (filterKey) {
       case 'text':
@@ -52,7 +52,7 @@ const passFilters = (rule, filters) =>
     }
   });
 
-const passFiltersCluster = (cluster, filters) =>
+export const passFiltersCluster = (cluster, filters) =>
   Object.entries(filters).every(([filterKey, filterValue]) => {
     switch (filterKey) {
       case 'text':
@@ -73,7 +73,7 @@ const passFiltersCluster = (cluster, filters) =>
     }
   });
 
-const mapClustersToRows = (clusters) =>
+export const mapClustersToRows = (clusters) =>
   clusters.map((cluster, index) => ({
     cluster,
     cells: [
@@ -111,9 +111,10 @@ const mapClustersToRows = (clusters) =>
     ],
   }));
 
-const capitalize = (string) => string[0].toUpperCase() + string.substring(1);
+export const capitalize = (string) =>
+  string[0].toUpperCase() + string.substring(1);
 
-const pruneFilters = (localFilters, filterCategories) => {
+export const pruneFilters = (localFilters, filterCategories) => {
   const prunedFilters = Object.entries(localFilters || {});
   return prunedFilters.reduce((arr, it) => {
     const [key, item] = it;
@@ -165,8 +166,8 @@ const pruneFilters = (localFilters, filterCategories) => {
   }, []);
 };
 
-const buildFilterChips = (filters, categories) => {
-  const localFilters = _.cloneDeep(filters);
+export const buildFilterChips = (filters, categories) => {
+  const localFilters = cloneDeep(filters);
   delete localFilters.sortIndex;
   delete localFilters.sortDirection;
   delete localFilters.offset;
@@ -177,10 +178,27 @@ const buildFilterChips = (filters, categories) => {
   return pruneFilters(localFilters, categories);
 };
 
-export {
-  passFilters,
-  passFiltersCluster,
-  mapClustersToRows,
-  buildFilterChips,
-  capitalize,
+// parses url params for use in table/filter chips
+export const paramParser = (search) => {
+  const searchParams = new URLSearchParams(search);
+  return Array.from(searchParams).reduce(
+    (acc, [key, value]) => ({
+      ...acc,
+      [key]:
+        key === 'text'
+          ? // just copy the full value
+            value
+          : value === 'true' || value === 'false'
+          ? // parse boolean
+            JSON.parse(value)
+          : // parse array of values
+            value.split(','),
+    }),
+    {}
+  );
 };
+
+export const translateSortParams = (value) => ({
+  sortValue: value.substring(value.startsWith('-') ? 1 : 0),
+  sortDirection: value.startsWith('-') ? 'desc' : 'asc',
+});

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -202,3 +202,17 @@ export const translateSortParams = (value) => ({
   sortValue: value.substring(value.startsWith('-') ? 1 : 0),
   sortDirection: value.startsWith('-') ? 'desc' : 'asc',
 });
+
+export const debounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [delay, value]);
+
+  return debouncedValue;
+};

--- a/src/Components/Labels/CategoryLabel.js
+++ b/src/Components/Labels/CategoryLabel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { camelCase } from 'lodash';
+import camelCase from 'lodash/camelCase';
 
 import { Label } from '@patternfly/react-core/dist/js/components/Label/index';
 import { LabelGroup } from '@patternfly/react-core/dist/js/components/LabelGroup/LabelGroup';

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -101,23 +101,16 @@ const RecsListTable = ({ query }) => {
       paramsObject.text === undefined
         ? setSearchText('')
         : setSearchText(paramsObject.text);
-      if (paramsObject.sort === undefined) {
-        paramsObject.sortIndex = RECS_LIST_INITIAL_STATE.sortIndex;
-        paramsObject.sortDirection = RECS_LIST_INITIAL_STATE.sortDirection;
-      } else {
+      if (paramsObject.sort) {
         const sortObj = translateSortParams(paramsObject.sort[0]);
-        paramsObject.sortIndex = RECS_LIST_COLUMNS_KEYS.indexOf(
-          sortObj.sortValue
-        );
-        paramsObject.sortDirection = sortObj.sortDirection;
+        paramsObject.sortIndex = RECS_LIST_COLUMNS_KEYS.indexOf(sortObj.name);
+        paramsObject.sortDirection = sortObj.direction;
       }
-      paramsObject.offset === undefined
-        ? (paramsObject.offset = RECS_LIST_INITIAL_STATE.offset)
-        : (paramsObject.offset = Number(paramsObject.offset[0]));
-      paramsObject.limit === undefined
-        ? (paramsObject.limit = RECS_LIST_INITIAL_STATE.limit)
-        : (paramsObject.limit = Number(paramsObject.limit[0]));
-      paramsObject.impacting !== undefined &&
+      paramsObject.offset &&
+        (paramsObject.offset = Number(paramsObject.offset[0]));
+      paramsObject.limit &&
+        (paramsObject.limit = Number(paramsObject.limit[0]));
+      paramsObject.impacting &&
         !Array.isArray(paramsObject.impacting) &&
         (paramsObject.impacting = [`${paramsObject.impacting}`]);
       updateFilters({ ...filters, ...paramsObject });

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import cloneDeep from 'lodash/cloneDeep';
+import capitalize from 'lodash/capitalize';
 import {
   SortByDirection,
   Table,
@@ -48,7 +49,6 @@ import { ErrorState, NoMatchingRecs } from '../MessageState/EmptyStates';
 import RuleDetails from '../Recommendation/RuleDetails';
 import {
   passFilters,
-  capitalize,
   paramParser,
   translateSortParams,
   debounce,

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+// single recommendation page
 export const AFFECTED_CLUSTERS_INITIAL_STATE = {
   limit: 20,
   offset: 0,
@@ -8,6 +9,7 @@ export const AFFECTED_CLUSTERS_INITIAL_STATE = {
   sortDirection: null,
 };
 
+// recommendations list page
 export const RECS_LIST_INITIAL_STATE = {
   limit: 20,
   offset: 0,
@@ -18,6 +20,7 @@ export const RECS_LIST_INITIAL_STATE = {
   rule_status: 'enabled',
 };
 
+// clusters list page
 export const CLUSTERS_LIST_INITIAL_STATE = {
   limit: 20,
   offset: 0,
@@ -27,24 +30,42 @@ export const CLUSTERS_LIST_INITIAL_STATE = {
   text: '',
 };
 
+// single cluster page
+export const CLUSTER_RULES_INITIAL_STATE = {
+  limit: 20,
+  offset: 0,
+  // default sorting by total risk
+  sortIndex: -1,
+  sortDirection: 'desc',
+  text: '',
+};
+
 const filtersInitialState = {
   affectedClustersState: AFFECTED_CLUSTERS_INITIAL_STATE,
   recsListState: RECS_LIST_INITIAL_STATE,
   clustersListState: CLUSTERS_LIST_INITIAL_STATE,
+  clusterRulesState: CLUSTER_RULES_INITIAL_STATE,
 };
 
 const filters = createSlice({
   name: 'filters',
   initialState: filtersInitialState,
   reducers: {
+    // single recommendation page
     updateAffectedClustersFilters(state, action) {
       state.affectedClustersState = action.payload;
     },
+    // recommendations list page
     updateRecsListFilters(state, action) {
       state.recsListState = action.payload;
     },
+    // clusters list page
     updateClustersListFilters(state, action) {
       state.clustersListState = action.payload;
+    },
+    // single cluster page
+    updateClusterRulesFilters(state, action) {
+      state.clusterRulesState = action.payload;
     },
   },
 });
@@ -55,6 +76,7 @@ export const {
   updateRecsListSortIndex,
   updateRecListSortDirection,
   updateClustersListFilters,
+  updateClusterRulesFilters,
 } = filters.actions;
 
 export default filters.reducer;


### PR DESCRIPTION
If the page is requested with the additional search (query) parameters (e.g., `?limit=20&offset=0&total_risk=1,2`), then apply the filters in the table.

- [x] Recs list page: apply filters using pre-filled URL search parameters
This enables usage of `total_risk`, `category`, `likelihood`, `impact`, `text` and other parameters to be added to the URL as search query parameters. Once added, the table will pre-fill the appropriate filters.
- [x] Single cluster page: apply filters using pre-filled URL search parameters
This enables usage of `total_risk`, `category`, `text` and other parameters to be added to the URL as search query parameters. Once added, the table will pre-fill the appropriate filters.
- [x] Single cluster page: add "first" query parameter (if the rule id given by this parameter, show it first in the table)
This enables usage of the `first` parameter to be added to the URL as a search query parameter. Once added with the valid rule ID, it will try to find the rule from the list of affecting recommendations and show it as the first item.

Examples:
- https://console.redhat.com/beta/openshift/insights/advisor/recommendations?total_risk=1,2 (show low, moderate total risks)
- https://console.redhat.com/beta/openshift/insights/advisor/recommendations?text=foo+bar (add "foo bar' name filter)
- https://console.redhat.com/beta/openshift/insights/advisor/clusters/foo-bar-id-cluster?first=ccx_rules_ocp.external.rules.nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET (show the rule with the ID ccx_rules_ocp.external.rules.nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET first if present in the list)