### PR TITLE
Compact Labels in Recommendations Table

### DIFF
--- a/src/Components/Labels/CategoryLabel.js
+++ b/src/Components/Labels/CategoryLabel.js
@@ -27,14 +27,14 @@ const CategoryLabel = ({ tags }) => {
   const intl = useIntl();
 
   return (
-    <LabelGroup numLabels={4}>
+    <LabelGroup numLabels={1} isCompact>
       {extractCategories(tags).map((tag, key) => (
         <Label
           key={key}
           icon={CATEGORY_ICONS[tag]}
           variant="outline"
           color="blue"
-          isCompact="true"
+          isCompact
         >
           {intl.formatMessage(messages[camelCase(tag)])}
         </Label>

--- a/src/Components/Labels/CategoryLabel.js
+++ b/src/Components/Labels/CategoryLabel.js
@@ -34,6 +34,7 @@ const CategoryLabel = ({ tags }) => {
           icon={CATEGORY_ICONS[tag]}
           variant="outline"
           color="blue"
+          isCompact="true"
         >
           {intl.formatMessage(messages[camelCase(tag)])}
         </Label>

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -104,7 +104,7 @@ const RecsListTable = ({ query }) => {
                     {' '}
                     {value?.description || value?.rule_id}{' '}
                   </Link>
-                  <RuleLabels rule={value} />
+                  <RuleLabels rule={value} isCompact="true" />
                 </span>
               ),
             },
@@ -119,7 +119,9 @@ const RecsListTable = ({ query }) => {
                 intl.formatMessage(messages.nA)
               ),
             },
-            { title: <CategoryLabel key={key} tags={value.tags} /> },
+            {
+              title: <CategoryLabel key={key} tags={value.tags} />,
+            },
             {
               title: (
                 <div key={key}>
@@ -137,7 +139,10 @@ const RecsListTable = ({ query }) => {
                     )}
                   >
                     {value?.total_risk ? (
-                      <InsightsLabel value={value.total_risk} />
+                      <InsightsLabel
+                        value={value.total_risk}
+                        rest={{ isCompact: true }}
+                      />
                     ) : (
                       intl.formatMessage(messages.nA)
                     )}

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -104,7 +104,7 @@ const RecsListTable = ({ query }) => {
                     {' '}
                     {value?.description || value?.rule_id}{' '}
                   </Link>
-                  <RuleLabels rule={value} isCompact="true" />
+                  <RuleLabels rule={value} />
                 </span>
               ),
             },


### PR DESCRIPTION
Added props isCompact to the labels in Recommendations List Table
To update the label total risk in the expanded rule we need to create a separate patch for the rhel advisor
Asked Martin about <InsightsLabel /> props and he told me that there is a bug so currently, we need to pass rest={{ isCompact: true }} instead isCompact="true" to get the result we need.

![image](https://user-images.githubusercontent.com/62722417/148945392-c162739a-5a8e-4f2f-8c1a-a308eb5a451f.png)

