### PR TITLE
Fix corner case when cluster list receive 0 clusters

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -1,5 +1,4 @@
 {
-  "NoRecsForClusters": "No known recommendations affect this cluster",
   "actions": "Actions",
   "added": "Added",
   "affectedClusters": "Affected clusters",
@@ -59,6 +58,8 @@
   "noRecommendationsDesc": "No known recommendations affect this cluster.",
   "noRecsError": "No recommendations available.",
   "noRecsErrorDesc": "There was an error fetching recommendations for this cluster. Refresh your page to try again.",
+  "noRecsForClusterListBody": "To get started, create or register your cluster to get recommendations from Insights Advisor.",
+  "noRecsForClusterListTitle": "No clusters yet",
   "noRecsFoundError": "No recommendations to display",
   "noRecsFoundErrorDesc": "Insights identifies and prioritizes risks to security, performance, availability, and stability of your clusters. This feature uses the Remote Health functionality of OpenShift Container Platform. For further details about Insights, see the",
   "none": "None",

--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -1,4 +1,5 @@
 {
+  "NoRecsForClusters": "No known recommendations affect this cluster",
   "actions": "Actions",
   "added": "Added",
   "affectedClusters": "Affected clusters",

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -11,6 +11,8 @@ import {
   TableVariant,
 } from '@patternfly/react-table';
 import { Card, CardBody } from '@patternfly/react-core/dist/js/components/Card';
+import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye';
+import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
 import {
   Pagination,
   PaginationVariant,
@@ -176,7 +178,11 @@ const ClustersListTable = ({
 
   return (
     <>
-      {clusters.length === 0 ? (
+      {isUninitialized || isFetching ? (
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      ) : clusters.length === 0 ? (
         <NoRecsForClusters />
       ) : (
         <div id="clusters-list-table">

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -34,7 +34,11 @@ import {
 } from '../Common/Tables';
 import Loading from '../Loading/Loading';
 import messages from '../../Messages';
-import { ErrorState, NoMatchingClusters } from '../MessageState/EmptyStates';
+import {
+  ErrorState,
+  NoMatchingClusters,
+  NoRecsForClusters,
+} from '../MessageState/EmptyStates';
 
 const ClustersListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data },
@@ -216,12 +220,21 @@ const ClustersListTable = ({
             <TableHeader />
             <TableBody />
           </Table>
-          {clusters.length >= 0 && filteredRows.length === 0 && (
+          {clusters.length === 0 ? (
             <Card ouiaId="empty-state">
               <CardBody>
-                <NoMatchingClusters />
+                <NoRecsForClusters />
               </CardBody>
             </Card>
+          ) : (
+            clusters.length > 0 &&
+            filteredRows.length === 0 && (
+              <Card ouiaId="empty-state">
+                <CardBody>
+                  <NoMatchingClusters />
+                </CardBody>
+              </Card>
+            )
           )}
         </React.Fragment>
       )}

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -177,11 +177,7 @@ const ClustersListTable = ({
   return (
     <>
       {clusters.length === 0 ? (
-        <Card ouiaId="empty-state">
-          <CardBody>
-            <NoRecsForClusters />
-          </CardBody>
-        </Card>
+        <NoRecsForClusters />
       ) : (
         <div id="clusters-list-table">
           <PrimaryToolbar
@@ -228,7 +224,7 @@ const ClustersListTable = ({
                 <TableHeader />
                 <TableBody />
               </Table>
-              {clusters.length > 0 && filteredRows.length === 0 && (
+              {filteredRows.length === 0 && (
                 <Card ouiaId="empty-state">
                   <CardBody>
                     <NoMatchingClusters />

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -216,7 +216,7 @@ const ClustersListTable = ({
             <TableHeader />
             <TableBody />
           </Table>
-          {clusters.length > 0 && filteredRows.length === 0 && (
+          {clusters.length >= 0 && filteredRows.length === 0 && (
             <Card ouiaId="empty-state">
               <CardBody>
                 <NoMatchingClusters />

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -175,87 +175,88 @@ const ClustersListTable = ({
   };
 
   return (
-    <div id="clusters-list-table">
-      <PrimaryToolbar
-        pagination={{
-          itemCount: filteredRows.length,
-          page,
-          perPage: filters.limit,
-          onSetPage: (_event, page) =>
-            updateFilters({
-              ...filters,
-              offset: filters.limit * (page - 1),
-            }),
-          onPerPageSelect: (_event, perPage) =>
-            updateFilters({ ...filters, limit: perPage, offset: 0 }),
-          isCompact: true,
-          ouiaId: 'pager',
-        }}
-        filterConfig={{ items: filterConfigItems }}
-        activeFiltersConfig={activeFiltersConfig}
-      />
-      {(isUninitialized || isFetching) && <Loading />}
-      {isError && (
-        <Card ouiaId="error-state">
+    <>
+      {clusters.length === 0 ? (
+        <Card ouiaId="empty-state">
           <CardBody>
-            <ErrorState />
+            <NoRecsForClusters />
           </CardBody>
         </Card>
-      )}
-      {!(isUninitialized || isFetching) && isSuccess && (
-        <React.Fragment>
-          <Table
-            aria-label="Table of clusters"
-            ouiaId="clusters"
-            variant={TableVariant.compact}
-            cells={CLUSTERS_LIST_COLUMNS}
-            rows={displayedRows}
-            sortBy={{
-              index: filters.sortIndex,
-              direction: filters.sortDirection,
+      ) : (
+        <div id="clusters-list-table">
+          <PrimaryToolbar
+            pagination={{
+              itemCount: filteredRows.length,
+              page,
+              perPage: filters.limit,
+              onSetPage: (_event, page) =>
+                updateFilters({
+                  ...filters,
+                  offset: filters.limit * (page - 1),
+                }),
+              onPerPageSelect: (_event, perPage) =>
+                updateFilters({ ...filters, limit: perPage, offset: 0 }),
+              isCompact: true,
+              ouiaId: 'pager',
             }}
-            onSort={onSort}
-            isStickyHeader
-          >
-            <TableHeader />
-            <TableBody />
-          </Table>
-          {clusters.length === 0 ? (
-            <Card ouiaId="empty-state">
+            filterConfig={{ items: filterConfigItems }}
+            activeFiltersConfig={activeFiltersConfig}
+          />
+          {(isUninitialized || isFetching) && <Loading />}
+          {isError && (
+            <Card ouiaId="error-state">
               <CardBody>
-                <NoRecsForClusters />
+                <ErrorState />
               </CardBody>
             </Card>
-          ) : (
-            clusters.length > 0 &&
-            filteredRows.length === 0 && (
-              <Card ouiaId="empty-state">
-                <CardBody>
-                  <NoMatchingClusters />
-                </CardBody>
-              </Card>
-            )
           )}
-        </React.Fragment>
+          {!(isUninitialized || isFetching) && isSuccess && (
+            <React.Fragment>
+              <Table
+                aria-label="Table of clusters"
+                ouiaId="clusters"
+                variant={TableVariant.compact}
+                cells={CLUSTERS_LIST_COLUMNS}
+                rows={displayedRows}
+                sortBy={{
+                  index: filters.sortIndex,
+                  direction: filters.sortDirection,
+                }}
+                onSort={onSort}
+                isStickyHeader
+              >
+                <TableHeader />
+                <TableBody />
+              </Table>
+              {clusters.length > 0 && filteredRows.length === 0 && (
+                <Card ouiaId="empty-state">
+                  <CardBody>
+                    <NoMatchingClusters />
+                  </CardBody>
+                </Card>
+              )}
+            </React.Fragment>
+          )}
+          <Pagination
+            ouiaId="pager"
+            itemCount={filteredRows.length}
+            page={filters.offset / filters.limit + 1}
+            perPage={Number(filters.limit)}
+            onSetPage={(_e, page) =>
+              updateFilters({
+                ...filters,
+                offset: filters.limit * (page - 1),
+              })
+            }
+            onPerPageSelect={(_e, perPage) =>
+              updateFilters({ ...filters, limit: perPage, offset: 0 })
+            }
+            widgetId={`pagination-options-menu-bottom`}
+            variant={PaginationVariant.bottom}
+          />
+        </div>
       )}
-      <Pagination
-        ouiaId="pager"
-        itemCount={filteredRows.length}
-        page={filters.offset / filters.limit + 1}
-        perPage={Number(filters.limit)}
-        onSetPage={(_e, page) =>
-          updateFilters({
-            ...filters,
-            offset: filters.limit * (page - 1),
-          })
-        }
-        onPerPageSelect={(_e, perPage) =>
-          updateFilters({ ...filters, limit: perPage, offset: 0 })
-        }
-        widgetId={`pagination-options-menu-bottom`}
-        variant={PaginationVariant.bottom}
-      />
-    </div>
+    </>
   );
 };
 

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -172,3 +172,33 @@ describe('clusters list table', () => {
     cy.getLastRow().find('span').should('have.text', 'N/A');
   });
 });
+
+describe('cluster list Empty state rendering', () => {
+  beforeEach(() => {
+    mount(
+      <MemoryRouter initialEntries={['/clusters']} initialIndex={0}>
+        <Intl>
+          <Provider store={getStore()}>
+            <ClustersListTable
+              query={{
+                isError: false,
+                isFetching: false,
+                isUninitialized: false,
+                isSuccess: true,
+                data: [],
+              }}
+            />
+          </Provider>
+        </Intl>
+      </MemoryRouter>
+    );
+  });
+
+  it('renders table', () => {
+    cy.get('div[id=clusters-list-table]').should('have.length', 1);
+  });
+
+  it('renders the Empty State component', () => {
+    cy.get('div[class=pf-c-empty-state]').should('have.length', 1);
+  });
+});

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -207,9 +207,13 @@ describe('cluster list Empty state rendering', () => {
       .children()
       .eq(3)
       .should('have.text', 'Create cluster');
-    cy.get('div[class=pf-c-empty-state__content]')
+    cy.get('div[class=pf-c-empty-state__secondary]')
       .children()
-      .eq(4)
-      .should('have.text', 'Register clusterAssisted Installer clusters');
+      .eq(0)
+      .should('have.text', 'Register cluster');
+    cy.get('div[class=pf-c-empty-state__secondary]')
+      .children()
+      .eq(1)
+      .should('have.text', 'Assisted Installer clusters');
   });
 });

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -194,11 +194,22 @@ describe('cluster list Empty state rendering', () => {
     );
   });
 
-  it('renders table', () => {
-    cy.get('div[id=clusters-list-table]').should('have.length', 1);
-  });
-
   it('renders the Empty State component', () => {
-    cy.get('div[class=pf-c-empty-state]').should('have.length', 1);
+    cy.get('div[class=pf-c-empty-state__content]')
+      .should('have.length', 1)
+      .find('h2')
+      .should('have.text', 'No clusters yet');
+    cy.get('div[class=pf-c-empty-state__body]').should(
+      'have.text',
+      'To get started, create or register your cluster to get recommendations from Insights Advisor.'
+    );
+    cy.get('div[class=pf-c-empty-state__content]')
+      .children()
+      .eq(3)
+      .should('have.text', 'Create cluster');
+    cy.get('div[class=pf-c-empty-state__content]')
+      .children()
+      .eq(4)
+      .should('have.text', 'Register clusterAssisted Installer clusters');
   });
 });

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -8,11 +8,12 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
+  EmptyStateSecondaryActions,
 } from '@patternfly/react-core/dist/js/components/EmptyState';
 import { Button } from '@patternfly/react-core/dist/js/components/Button';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 import { global_success_color_100 as globalSuccessColor100 } from '@patternfly/react-tokens/dist/js/global_success_color_100';
 import { global_danger_color_100 as globalDangerColor100 } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import { InProgressIcon } from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
@@ -114,14 +115,37 @@ const ComingSoon = () => {
 const NoRecsForClusters = () => {
   const intl = useIntl();
   return (
-    <EmptyState variant="small" id="coming-soon-message">
-      <EmptyStateIcon icon={CheckIcon} color="#1E4F18" />
+    <EmptyState variant="small">
+      <EmptyStateIcon icon={PlusCircleIcon} />
       <Title headingLevel="h2" size="2xl">
         {intl.formatMessage(messages.noRecsForClusterListTitle)}
       </Title>
       <EmptyStateBody>
         {intl.formatMessage(messages.noRecsForClusterListBody)}
       </EmptyStateBody>
+      <Button
+        component="a"
+        variant="primary"
+        href="https://console.redhat.com/openshift/create"
+      >
+        Create cluster
+      </Button>
+      <EmptyStateSecondaryActions>
+        <Button
+          component="a"
+          variant="link"
+          href="https://console.redhat.com/openshift/register"
+        >
+          Register cluster
+        </Button>
+        <Button
+          component="a"
+          variant="link"
+          href="https://console.redhat.com/openshift/assisted-installer/clusters"
+        >
+          Assisted Installer clusters
+        </Button>
+      </EmptyStateSecondaryActions>
     </EmptyState>
   );
 };

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -12,6 +12,7 @@ import {
 import { Button } from '@patternfly/react-core/dist/js/components/Button';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
 import { global_success_color_100 as globalSuccessColor100 } from '@patternfly/react-tokens/dist/js/global_success_color_100';
 import { global_danger_color_100 as globalDangerColor100 } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import { InProgressIcon } from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
@@ -110,10 +111,26 @@ const ComingSoon = () => {
   );
 };
 
+const NoRecsForClusters = () => {
+  const intl = useIntl();
+  return (
+    <EmptyState variant="small" id="coming-soon-message">
+      <EmptyStateIcon icon={CheckIcon} color="#1E4F18" />
+      <Title headingLevel="h2" size="2xl">
+        {intl.formatMessage(messages.noRecsForClusterListTitle)}
+      </Title>
+      <EmptyStateBody>
+        {intl.formatMessage(messages.noRecsForClusterListBody)}
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
 export {
   ErrorState,
   NoAffectedClusters,
   NoMatchingClusters,
   NoMatchingRecs,
   ComingSoon,
+  NoRecsForClusters,
 };

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -547,4 +547,14 @@ export default defineMessages({
     description: 'Action, Bulk select all items in a table with number',
     defaultMessage: 'Select all ({items} items)',
   },
+  noRecsForClusterListTitle: {
+    id: 'NoRecsForClusters',
+    description: 'Cluster List Page received 0 clusters',
+    defaultMessage: 'No recommendations',
+  },
+  noRecsForClusterListBody: {
+    id: 'NoRecsForClusters',
+    description: 'Cluster List Page received 0 clusters',
+    defaultMessage: 'No known recommendations affect this cluster',
+  },
 });

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -548,13 +548,14 @@ export default defineMessages({
     defaultMessage: 'Select all ({items} items)',
   },
   noRecsForClusterListTitle: {
-    id: 'NoRecsForClusters',
+    id: 'noRecsForClusterListTitle',
     description: 'Cluster List Page received 0 clusters',
-    defaultMessage: 'No recommendations',
+    defaultMessage: 'No clusters yet',
   },
   noRecsForClusterListBody: {
-    id: 'NoRecsForClusters',
+    id: 'noRecsForClusterListBody',
     description: 'Cluster List Page received 0 clusters',
-    defaultMessage: 'No known recommendations affect this cluster',
+    defaultMessage:
+      'To get started, create or register your cluster to get recommendations from Insights Advisor.',
   },
 });


### PR DESCRIPTION
New empty state for the Clusters table that will be rendered when the clusters.length === 0 
![image](https://user-images.githubusercontent.com/62722417/149931192-94981315-6e40-4e87-b571-815c691e1fcf.png)
