### PR TITLE
Fixed a style in the recommendation table name column and single recommendation page

### DIFF
--- a/src/Components/Labels/RuleLabels.js
+++ b/src/Components/Labels/RuleLabels.js
@@ -18,7 +18,9 @@ const RuleLabels = ({ rule }) => {
           content={intl.formatMessage(messages.ruleIsDisabledTooltip)}
           position={TooltipPosition.right}
         >
-          <Label color="gray">{intl.formatMessage(messages.disabled)}</Label>
+          <Label color="gray" isCompact>
+            {intl.formatMessage(messages.disabled)}
+          </Label>
         </Tooltip>
       )}
     </React.Fragment>

--- a/src/Components/Recommendation/Recommendation.js
+++ b/src/Components/Recommendation/Recommendation.js
@@ -197,11 +197,19 @@ const Recommendation = ({ rule, ack, clusters, match }) => {
                     })}
                     {content.tags &&
                       (Array.isArray(content.tags) ? (
-                        <LabelGroup className="categoryLabels" numLabels={1}>
+                        <LabelGroup
+                          className="categoryLabels"
+                          numLabels={1}
+                          isCompact
+                        >
                           {content.tags.reduce((labels, tag) => {
                             if (RULE_CATEGORIES[tag]) {
                               labels.push(
-                                <Label key={`label-${tag}`} color="blue">
+                                <Label
+                                  key={`label-${tag}`}
+                                  color="blue"
+                                  isCompact
+                                >
                                   {
                                     FILTER_CATEGORIES.category.values[
                                       RULE_CATEGORIES[tag] - 1
@@ -214,7 +222,7 @@ const Recommendation = ({ rule, ack, clusters, match }) => {
                           }, [])}
                         </LabelGroup>
                       ) : (
-                        <Label>{content.tags}</Label>
+                        <Label isCompact>{content.tags}</Label>
                       ))}
                   </p>
                 </React.Fragment>

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -226,7 +226,11 @@ describe('successful non-empty recommendations list table', () => {
     cy.removeStatusFilter();
     cy.getAllRows().should('have.length', 5);
     cy.getRowByName('disabled rule with 2 impacted')
-      .find('span[class=pf-c-label]')
+      .children()
+      .eq(0)
+      .children()
+      .eq(1)
+      .find('span[class=pf-c-label__content]')
       .should('have.text', 'Disabled');
   });
 


### PR DESCRIPTION
The style for the label in the name column was missing the isCompact props
![image](https://user-images.githubusercontent.com/62722417/150120852-f65f1ec7-4b57-4c99-9601-f46be34be40f.png)
