### PR TITLE
Cluster recs: support "first" query parameter

### DIFF
--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -147,7 +147,9 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
         ...r,
         cells: [
           <span key={r.id}>
-            <Link to={`/clusters/${r.id}`}>{r.cells[0]}</Link>
+            <Link to={`/clusters/${r.id}?first=${rule.rule_id}`}>
+              {r.cells[0]}
+            </Link>
           </span>,
         ],
       }));

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -182,15 +182,12 @@ export const paramParser = (search) => {
   return Array.from(searchParams).reduce(
     (acc, [key, value]) => ({
       ...acc,
-      [key]:
-        key === 'text'
-          ? // just copy the full value
-            value
-          : value === 'true' || value === 'false'
-          ? // parse boolean
-            JSON.parse(value)
-          : // parse array of values
-            value.split(','),
+      [key]: ['text', 'first'].includes(key)
+        ? value // just copy the full value
+        : value === 'true' || value === 'false'
+        ? JSON.parse(value) // parse boolean
+        : // parse array of values
+          value.split(','),
     }),
     {}
   );


### PR DESCRIPTION
The patch enables the usage of the "first" query parameter with the rule id as a valid value. If given, the list will show the requested rule as the first in hitting recommendations for this cluster.

- [x] Single cluster page: accept the `first` query parameters
- [x] Single recommendation page: change the link to each of the clusters