### PR TITLE
Affected clusters table sorting update

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -253,6 +253,8 @@ export const RECS_LIST_COLUMNS_KEYS = [
   'total_risk',
   'impacted_clusters_count',
 ];
+export const AFFECTED_CLUSTERS_NAME_CELL = 1;
+export const AFFECTED_CLUSTERS_LAST_SEEN = 2;
 export const AFFECTED_CLUSTERS_COLUMNS = [
   {
     title: intl.formatMessage(messages.name),

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -25,7 +25,11 @@ import {
   NoAffectedClusters,
   NoMatchingClusters,
 } from '../MessageState/EmptyStates';
-import { AFFECTED_CLUSTERS_COLUMNS } from '../../AppConstants';
+import {
+  AFFECTED_CLUSTERS_COLUMNS,
+  AFFECTED_CLUSTERS_LAST_SEEN,
+  AFFECTED_CLUSTERS_NAME_CELL,
+} from '../../AppConstants';
 import Loading from '../Loading/Loading';
 import { updateAffectedClustersFilters } from '../../Services/Filters';
 import messages from '../../Messages';
@@ -134,10 +138,19 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
         return row?.cells[0].toLowerCase().includes(filters.text.toLowerCase());
       })
       .sort((a, b) => {
-        if (filters.sortDirection === 'asc') {
-          return a?.cells[0].localeCompare(b?.cells[0]);
+        let fst, snd;
+        const d = filters.sortDirection === 'asc' ? 1 : -1;
+        switch (filters.sortIndex) {
+          case AFFECTED_CLUSTERS_NAME_CELL:
+            if (filters.sortDirection === 'asc') {
+              return a?.cells[0].localeCompare(b?.cells[0]);
+            }
+            return b?.cells[0].localeCompare(a?.cells[0]);
+          case AFFECTED_CLUSTERS_LAST_SEEN:
+            fst = new Date(a.last_checked_at || 0);
+            snd = new Date(b.last_checked_at || 0);
+            return fst > snd ? d : snd > fst ? -d : 0;
         }
-        return b?.cells[0].localeCompare(a?.cells[0]);
       });
   };
 

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -205,22 +205,26 @@ describe('non-empty successful affected clusters table', () => {
 
   it('sorting the last seen column', () => {
     cy.get(TABLE)
-      .find('td[data-key=2]')
+      .find('td[data-key=1]')
       .children()
       .eq(0)
-      .should('have.text', '2 years ago');
-    cy.get('.pf-c-table__sort').eq(1).click();
+      .should('have.text', '694d3942-9cb7-42b8-aad2-1f28cc7f0a3b');
   });
 
   it('sorts N/A in last seen correctly', () => {
     cy.get(TABLE);
     cy.get('.pf-c-table__sort').eq(1).click();
     cy.get(TABLE)
-      .find('td[data-key=2]')
+      .find('td[data-key=1]')
       .children()
       .eq(0)
-      .should('have.text', 'N/A');
+      .should('have.text', 'foobar cluster');
     cy.get('.pf-c-table__sort').eq(1).click();
+    cy.get(TABLE)
+      .find('td[data-key=1]')
+      .children()
+      .eq(0)
+      .should('have.text', 'dd2ef343-9131-46f5-8962-290fdfdf2199');
   });
 });
 

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -203,7 +203,18 @@ describe('non-empty successful affected clusters table', () => {
     });
   });
 
+  it('sorting the last seen column', () => {
+    cy.get(TABLE)
+      .find('td[data-key=2]')
+      .children()
+      .eq(0)
+      .should('have.text', '2 years ago');
+    cy.get('.pf-c-table__sort').eq(1).click();
+  });
+
   it('sorts N/A in last seen correctly', () => {
+    cy.get(TABLE);
+    cy.get('.pf-c-table__sort').eq(1).click();
     cy.get(TABLE)
       .find('td[data-key=2]')
       .children()


### PR DESCRIPTION
1)Fixed sorting in the affected clusters table on the single recommendation page.
2)Wrote test to check the sorting behaviour.
3)The tests show that it is up to our expectations (see the screenshots)

First click that causes sorting
![image](https://user-images.githubusercontent.com/62722417/151859287-297c25bd-f400-4bb8-89bc-9ad1ab67d2af.png)

Second click that causes sorting
![image](https://user-images.githubusercontent.com/62722417/151859330-219fa788-7b3a-442a-8976-58293157d326.png)
