### PR TITLE
Removed dependency of view

### DIFF
--- a/cypress/utils/components.js
+++ b/cypress/utils/components.js
@@ -1,0 +1,9 @@
+const TOOLBAR = 'div[id="ins-primary-data-toolbar"]';
+const CHIP_GROUP = 'div[data-ouia-component-type="PF4/ChipGroup"]';
+const CHIP = '[data-ouia-component-type="PF4/Chip"]';
+const ROW = '[data-ouia-component-type="PF4/TableRow"]';
+const PAGINATION = 'div[data-ouia-component-type="PF4/Pagination"]';
+const PAGINATION_MENU =
+  'div[data-ouia-component-type="PF4/PaginationOptionsMenu"]';
+
+export { TOOLBAR, CHIP_GROUP, CHIP, ROW, PAGINATION, PAGINATION_MENU };


### PR DESCRIPTION
Given that usage of views has been postponed it looks weird to mix both syntax.
Thus, we have removed the dependency of fiterableTable

I have not removed the views folder so it does not interfere with #91 Once both are merged, we can remove that dependency.