### PR TITLE
Fixed the single cluster page header display name

### DIFF
--- a/src/Components/Cluster/Cluster.js
+++ b/src/Components/Cluster/Cluster.js
@@ -19,7 +19,7 @@ import MessageState from '../MessageState/MessageState';
 import Loading from '../Loading/Loading';
 import messages from '../../Messages';
 
-export const Cluster = ({ cluster, displayName, match }) => {
+export const Cluster = ({ cluster, match }) => {
   const intl = useIntl();
   const {
     isError,
@@ -30,13 +30,14 @@ export const Cluster = ({ cluster, displayName, match }) => {
     data,
     error,
   } = cluster;
-  const { data: clusterDisplayName } = displayName;
 
   return (
     <React.Fragment>
       <PageHeader className="pf-m-light ins-inventory-detail">
         <Breadcrumbs
-          current={clusterDisplayName || match.params.clusterId}
+          current={
+            cluster?.data?.report.meta.cluster_name || match.params.clusterId
+          }
           match={match}
         />
         <ClusterHeader />

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -193,9 +193,6 @@ describe('Cluster page display name test №1', () => {
         isSuccess: true,
         data: singleClusterPageReport,
       },
-      displayName: {
-        data: 'Cluster With Issues',
-      },
       match: {
         params: {
           clusterId: 'Cluster Id',
@@ -221,16 +218,12 @@ describe('Cluster page display name test №1', () => {
       .should('have.text', 'Cluster With Issues');
   });
 
-  it('Cluster breadcrumbs name should be = Cluster Id because we didnt passed displayName', () => {
+  it('Cluster breadcrumbs name should be = Cluster Id', () => {
     mount(
       <MemoryRouter>
         <Intl>
           <Provider store={getStore()}>
-            <Cluster
-              cluster={props.cluster}
-              displayName="foobar"
-              match={props.match}
-            />
+            <Cluster cluster="" match={props.match} />
           </Provider>
         </Intl>
       </MemoryRouter>

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -182,12 +182,8 @@ describe('cluster page', () => {
   });
 });
 
-describe('Cluster page display name test', () => {
+describe('Cluster page display name test №1', () => {
   before(() => {
-    cy.intercept(
-      'http://localhost:8002/api/insights-results-aggregator/v2/cluster/undefined/reports?get_disabled=false',
-      singleClusterPageReport
-    );
     props = {
       cluster: {
         isError: false,
@@ -198,17 +194,18 @@ describe('Cluster page display name test', () => {
         data: singleClusterPageReport,
       },
       displayName: {
-        data: singleClusterPageReport.report.meta.cluster_name,
+        data: 'Cluster With Issues',
       },
       match: {
         params: {
-          clusterId: 'foobar',
+          clusterId: 'Cluster Id',
         },
         url: 'foobar',
       },
     };
   });
-  it('Cluster breadcrumbs name and Cluster Header name should be Cluster With Issues', () => {
+
+  it('Cluster breadcrumbs name should be Cluster With Issues', () => {
     mount(
       <MemoryRouter>
         <Intl>
@@ -222,45 +219,18 @@ describe('Cluster page display name test', () => {
       .should('have.length', 1)
       .get('.pf-c-breadcrumb__list > :nth-child(2)')
       .should('have.text', 'Cluster With Issues');
-    cy.get(CLUSTER_HEADER)
-      .children()
-      .eq(0)
-      .should('have.text', 'Cluster With Issues');
-  });
-});
-
-describe('Display name test', () => {
-  before(() => {
-    cy.intercept(
-      'http://localhost:8002/api/insights-results-aggregator/v2/cluster/undefined/reports?get_disabled=false'
-    );
-    props = {
-      cluster: {
-        isError: false,
-        isUninitialized: false,
-        isLoading: false,
-        isFetching: false,
-        isSuccess: true,
-        data: singleClusterPageReport,
-      },
-      displayName: {
-        data: '',
-      },
-      match: {
-        params: {
-          clusterId: 'foobar',
-        },
-        url: 'foobar',
-      },
-    };
   });
 
-  it('Cluster breadcrumbs name should be = foobar because we didnt passed displayName', () => {
+  it('Cluster breadcrumbs name should be = Cluster Id because we didnt passed displayName', () => {
     mount(
       <MemoryRouter>
         <Intl>
           <Provider store={getStore()}>
-            <Cluster {...props} />
+            <Cluster
+              cluster={props.cluster}
+              displayName="foobar"
+              match={props.match}
+            />
           </Provider>
         </Intl>
       </MemoryRouter>
@@ -268,7 +238,6 @@ describe('Display name test', () => {
     cy.get(BREADCRUMBS)
       .should('have.length', 1)
       .get('.pf-c-breadcrumb__list > :nth-child(2)')
-      .should('have.text', 'foobar');
-    cy.get(CLUSTER_HEADER);
+      .should('have.text', 'Cluster Id');
   });
 });

--- a/src/Components/Cluster/index.js
+++ b/src/Components/Cluster/index.js
@@ -2,10 +2,7 @@ import React, { useEffect } from 'react';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/RouterParams';
 import { useIntl } from 'react-intl';
 
-import {
-  useGetClusterByIdQuery,
-  useGetDisplayNameQuery,
-} from '../../Services/SmartProxy';
+import { useGetClusterByIdQuery } from '../../Services/SmartProxy';
 import messages from '../../Messages';
 import { Cluster } from './Cluster';
 
@@ -15,10 +12,7 @@ export default routerParams(({ match }) => {
     id: match.params.clusterId,
     includeDisabled: false,
   });
-  const displayName = useGetDisplayNameQuery({
-    id: match.params.clusterId,
-    includeDisabled: false,
-  });
+
   useEffect(() => {
     cluster.refetch();
   }, [match.params.clusterId]);
@@ -31,5 +25,5 @@ export default routerParams(({ match }) => {
       document.title = intl.formatMessage(messages.documentTitle, { subnav });
     }
   }, [match.params.clusterId]);
-  return <Cluster cluster={cluster} displayName={displayName} match={match} />;
+  return <Cluster cluster={cluster} match={match} />;
 });

--- a/src/Components/Cluster/index.js
+++ b/src/Components/Cluster/index.js
@@ -2,10 +2,12 @@ import React, { useEffect } from 'react';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/RouterParams';
 import { useIntl } from 'react-intl';
 
-import { useGetClusterByIdQuery } from '../../Services/SmartProxy';
+import {
+  useGetClusterByIdQuery,
+  useGetDisplayNameQuery,
+} from '../../Services/SmartProxy';
 import messages from '../../Messages';
 import { Cluster } from './Cluster';
-import { useGetClusterDisplayNameByIdQuery } from '../../Services/AccountManagementService';
 
 export default routerParams(({ match }) => {
   const intl = useIntl();
@@ -13,8 +15,11 @@ export default routerParams(({ match }) => {
     id: match.params.clusterId,
     includeDisabled: false,
   });
-  const displayName = useGetClusterDisplayNameByIdQuery(match.params.clusterId);
-
+  const displayName = useGetDisplayNameQuery({
+    id: match.params.clusterId,
+    includeDisabled: false,
+  });
+  console.log(displayName);
   useEffect(() => {
     cluster.refetch();
   }, [match.params.clusterId]);

--- a/src/Components/Cluster/index.js
+++ b/src/Components/Cluster/index.js
@@ -19,7 +19,6 @@ export default routerParams(({ match }) => {
     id: match.params.clusterId,
     includeDisabled: false,
   });
-  console.log(displayName);
   useEffect(() => {
     cluster.refetch();
   }, [match.params.clusterId]);
@@ -32,6 +31,5 @@ export default routerParams(({ match }) => {
       document.title = intl.formatMessage(messages.documentTitle, { subnav });
     }
   }, [match.params.clusterId]);
-
   return <Cluster cluster={cluster} displayName={displayName} match={match} />;
 });

--- a/src/Components/ClusterHeader/ClusterHeader.js
+++ b/src/Components/ClusterHeader/ClusterHeader.js
@@ -11,13 +11,8 @@ import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat/Da
 import messages from '../../Messages';
 import { OneLineLoader } from '../../Utilities/Loaders';
 
-export const ClusterHeader = ({ clusterId, clusterData, displayName }) => {
+export const ClusterHeader = ({ clusterId, clusterData }) => {
   const intl = useIntl();
-  const {
-    isUninitialized: isUninitializedDisplayName,
-    isFetching: isFetchingDisplayName,
-    data: clusterName,
-  } = displayName;
   // subscribe to the cluster data query
   const {
     isUninitialized: isUninitializedCluster,
@@ -28,7 +23,7 @@ export const ClusterHeader = ({ clusterId, clusterData, displayName }) => {
   return (
     <Grid id="cluster-header" md={12} hasGutter>
       <GridItem>
-        {isUninitializedDisplayName || isFetchingDisplayName ? (
+        {isUninitializedCluster || isFetchingCluster ? (
           <Skeleton size="sm" />
         ) : (
           <Title
@@ -37,7 +32,7 @@ export const ClusterHeader = ({ clusterId, clusterData, displayName }) => {
             id="cluster-header-title"
             ouiaId="cluster-name"
           >
-            {clusterName || clusterId}
+            {clusterData?.data?.report?.meta.cluster_name || clusterId}
           </Title>
         )}
       </GridItem>

--- a/src/Components/ClusterHeader/ClusterHeader.js
+++ b/src/Components/ClusterHeader/ClusterHeader.js
@@ -18,7 +18,6 @@ export const ClusterHeader = ({ clusterId, clusterData, displayName }) => {
     isFetching: isFetchingDisplayName,
     data: clusterName,
   } = displayName;
-
   // subscribe to the cluster data query
   const {
     isUninitialized: isUninitializedCluster,

--- a/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
+++ b/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
@@ -70,6 +70,7 @@ describe('cluster page header', () => {
     // check uuid text
     cy.get(LAST_SEEN_FIELD).should('have.text', '24 Jul 2021 14:22 UTC');
   });
+
   it('show UUID when display name is unavailable', () => {
     props.displayName.data = undefined;
     mount(

--- a/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
+++ b/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
@@ -16,11 +16,6 @@ describe('cluster page header', () => {
   beforeEach(() => {
     props = {
       clusterId: 'foobar',
-      displayName: {
-        isUninitialized: false,
-        isFetching: false,
-        data: 'Cluster with issues',
-      },
       clusterData: {
         isUninitialized: false,
         isFetching: false,
@@ -63,8 +58,8 @@ describe('cluster page header', () => {
       </Intl>
     );
     // check title
-    cy.get(HEADER_TITLE).should('have.length', 0);
-    cy.get('.ins-c-skeleton').should('have.length', 1);
+    cy.get(HEADER_TITLE).should('have.length', 1);
+    cy.get('.ins-c-skeleton').should('have.length', 0);
     // check uuid text
     cy.get(UUID_FIELD).should('have.text', 'foobar');
     // check uuid text
@@ -72,7 +67,7 @@ describe('cluster page header', () => {
   });
 
   it('show UUID when display name is unavailable', () => {
-    props.displayName.data = undefined;
+    props.clusterData.data.report.meta.cluster_name = undefined;
     mount(
       <Intl>
         <ClusterHeader {...props} />

--- a/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
+++ b/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
@@ -25,7 +25,12 @@ describe('cluster page header', () => {
         isUninitialized: false,
         isFetching: false,
         data: {
-          report: { meta: { last_checked_at: '2021-07-24T14:22:36.109Z' } },
+          report: {
+            meta: {
+              last_checked_at: '2021-07-24T14:22:36.109Z',
+              cluster_name: 'Cluster with issues',
+            },
+          },
         },
       },
     };

--- a/src/Components/ClusterHeader/index.js
+++ b/src/Components/ClusterHeader/index.js
@@ -14,9 +14,10 @@ export default routerParams(({ match }) => {
     includeDisabled: false,
   });
   const displayName = useGetDisplayNameQuery({
-    id: match.params.clusterId,
+    id: clusterId,
     includeDisabled: false,
   });
+
   return (
     <ClusterHeader
       clusterId={clusterId}

--- a/src/Components/ClusterHeader/index.js
+++ b/src/Components/ClusterHeader/index.js
@@ -1,18 +1,22 @@
 import React from 'react';
 import { routerParams } from '@redhat-cloud-services/frontend-components-utilities/RouterParams/RouterParams';
 
-import { useGetClusterDisplayNameByIdQuery } from '../../Services/AccountManagementService';
-import { useGetClusterByIdQuery } from '../../Services/SmartProxy';
+import {
+  useGetClusterByIdQuery,
+  useGetDisplayNameQuery,
+} from '../../Services/SmartProxy';
 import { ClusterHeader } from './ClusterHeader';
 
 export default routerParams(({ match }) => {
   const clusterId = match.params.clusterId;
-  const displayName = useGetClusterDisplayNameByIdQuery(clusterId);
   const clusterData = useGetClusterByIdQuery({
     id: clusterId,
     includeDisabled: false,
   });
-
+  const displayName = useGetDisplayNameQuery({
+    id: match.params.clusterId,
+    includeDisabled: false,
+  });
   return (
     <ClusterHeader
       clusterId={clusterId}

--- a/src/Components/ClusterHeader/index.js
+++ b/src/Components/ClusterHeader/index.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { routerParams } from '@redhat-cloud-services/frontend-components-utilities/RouterParams/RouterParams';
 
-import {
-  useGetClusterByIdQuery,
-  useGetDisplayNameQuery,
-} from '../../Services/SmartProxy';
+import { useGetClusterByIdQuery } from '../../Services/SmartProxy';
 import { ClusterHeader } from './ClusterHeader';
 
 export default routerParams(({ match }) => {
@@ -13,16 +10,6 @@ export default routerParams(({ match }) => {
     id: clusterId,
     includeDisabled: false,
   });
-  const displayName = useGetDisplayNameQuery({
-    id: clusterId,
-    includeDisabled: false,
-  });
 
-  return (
-    <ClusterHeader
-      clusterId={clusterId}
-      displayName={displayName}
-      clusterData={clusterData}
-    />
-  );
+  return <ClusterHeader clusterId={clusterId} clusterData={clusterData} />;
 });

--- a/src/Services/AccountManagementService.js
+++ b/src/Services/AccountManagementService.js
@@ -23,13 +23,5 @@ export const AmsApi = createApi({
     getCurrentAccount: builder.query({
       query: () => `current_account`,
     }),
-    getClusterDisplayNameById: builder.query({
-      query: (clusterId) =>
-        `subscriptions?page=1&size=-1&search=external_cluster_id='${clusterId}'&fields=display_name`,
-      transformResponse: (response) => response?.items?.[0]?.display_name,
-    }),
   }),
 });
-
-// Export hooks for usage in functional components
-export const { useGetClusterDisplayNameByIdQuery } = AmsApi;

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -26,6 +26,11 @@ export const SmartProxyApi = createApi({
     getClusters: builder.query({
       query: () => `v2/clusters`,
     }),
+    getDisplayName: builder.query({
+      query: ({ id, includeDisabled }) =>
+        `v2/cluster/${id}/reports?get_disabled=${includeDisabled}`,
+      transformResponse: (response) => response?.report?.meta?.cluster_name,
+    }),
   }),
 });
 
@@ -38,4 +43,5 @@ export const {
   useGetRecsQuery,
   useLazyGetRecsQuery,
   useGetClustersQuery,
+  useGetDisplayNameQuery,
 } = SmartProxyApi;


### PR DESCRIPTION
Added a query to the smart proxy file that should get the display name for the cluster
attached it to the components
removed the unnecessary AMS query
![image](https://user-images.githubusercontent.com/62722417/153202571-f3d455e8-b595-4fc1-9788-f40122be9596.png)
![image](https://user-images.githubusercontent.com/62722417/153202618-4194d325-598c-4cf4-aedd-791ed971bb62.png)
