### PR TITLE
Added .report to api request

### DIFF
--- a/src/Services/Acks.js
+++ b/src/Services/Acks.js
@@ -27,7 +27,7 @@ const enableRuleForCluster = async ({ uuid, recId }) => {
   await Put(
     `${BASE_URL}/v1/clusters/${uuid}/rules/${getPluginName(
       recId
-    )}/error_key/${getErrorKey(recId)}/enable`
+    )}.report/error_key/${getErrorKey(recId)}/enable`
   );
 };
 
@@ -35,12 +35,12 @@ const disableRuleForCluster = async ({ uuid, recId, justification = '' }) => {
   await Put(
     `${BASE_URL}/v1/clusters/${uuid}/rules/${getPluginName(
       recId
-    )}/error_key/${getErrorKey(recId)}/disable`
+    )}.report/error_key/${getErrorKey(recId)}/disable`
   );
   await Post(
     `${BASE_URL}/v1/clusters/${uuid}/rules/${getPluginName(
       recId
-    )}/error_key/${getErrorKey(recId)}/disable_feedback`,
+    )}.report/error_key/${getErrorKey(recId)}/disable_feedback`,
     {},
     { message: justification }
   );


### PR DESCRIPTION
This change fixed a bug described in ccxdev-7244
After you disable the recommendation for one certain cluster it will be hidden from the list of recommendations on that cluster page.
I disabled this recommendation for the Custer With Issues
![image](https://user-images.githubusercontent.com/62722417/153422897-ce0756a1-9d4c-403d-af4d-f81b05308d87.png)

The recommendation is hidden and recommendation data wasn't fetched
![image](https://user-images.githubusercontent.com/62722417/153422950-29088114-b416-4788-a61f-8f83184a4afc.png)

After the page restart and restart the dev env. the recommendation is still disabled for this cluster
![image](https://user-images.githubusercontent.com/62722417/153423685-6957fbe1-2af7-4756-8961-cdcb8784c5c5.png)
