### PR TITLE
Fixed the cluster name in the modal

### DIFF
--- a/src/Components/Modals/ViewHostAcks.js
+++ b/src/Components/Modals/ViewHostAcks.js
@@ -72,7 +72,7 @@ const ViewHostAcks = ({
   useEffect(() => {
     const rows = hostAcks?.map((item) => ({
       cells: [
-        item.display_name || item.cluster_id,
+        item.cluster_name || item.cluster_id,
         item.justification || intl.formatMessage(messages.none),
         {
           title: (


### PR DESCRIPTION
The variable containing cluster_name was updated and required this change

Before
![image](https://user-images.githubusercontent.com/62722417/153889812-ec585f34-d4a7-4dc4-ba7a-05085851070f.png)

After
![image](https://user-images.githubusercontent.com/62722417/153889844-e0da9b78-be9d-4bbf-ab59-0d5798f0b8bf.png)
