### PR TITLE
Single cluster page disabled filter

### DIFF
--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -369,8 +369,7 @@ const ClusterRules = ({ reports }) => {
         expandAll={{ isAllExpanded, onClick: collapseAll }}
         filterConfig={{
           items: filterConfigItems,
-          isDisabled:
-            reports.length === 0 ? filteredRows.length === 0 : undefined,
+          isDisabled: reports.length === 0,
         }}
         pagination={
           <React.Fragment>

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -187,7 +187,7 @@ const ClusterRules = ({ reports }) => {
     } else if (firstRule) {
       const i = rows.findIndex((row) => {
         const rule = row[0].rule;
-        /* rule_id is given with the plugin name only, 
+        /* rule_id is given with the plugin name only,
            thus we need to look at extra_data for the error key */
         return (
           rule.rule_id.split('.report')[0] === getPluginName(firstRule) &&
@@ -369,7 +369,8 @@ const ClusterRules = ({ reports }) => {
         expandAll={{ isAllExpanded, onClick: collapseAll }}
         filterConfig={{
           items: filterConfigItems,
-          isDisabled: filteredRows.length === 0,
+          isDisabled:
+            reports.length === 0 ? filteredRows.length === 0 : undefined,
         }}
         pagination={
           <React.Fragment>


### PR DESCRIPTION
Added a ternary operator to check if the cluster has rule hits
If the cluster has 0 rule hits filter in the primary toolbar will be disabled
Otherwise, the filter in the primary toolbar will work

![image](https://user-images.githubusercontent.com/62722417/155325619-5d5608f5-5a74-4b30-925a-9446d9efd90e.png)

![image](https://user-images.githubusercontent.com/62722417/155325638-32a98a70-c8cc-4849-b415-f588b07a9ba0.png)
