### PR TITLE
Changed default sorting for the cluster list table

### DIFF
--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -25,7 +25,7 @@ export const CLUSTERS_LIST_INITIAL_STATE = {
   limit: 20,
   offset: 0,
   hits: ['all'],
-  sortIndex: -1,
+  sortIndex: 6,
   sortDirection: 'desc',
   text: '',
 };


### PR DESCRIPTION
Changed default sorting for the cluster list table to last seen.
That should push the N/A to the end of the cluster list table
![image](https://user-images.githubusercontent.com/62722417/155931704-4f4451d6-ece2-42aa-8cff-3557bd8b8550.png)
