### PR TITLE
Clusters list, recommendations list pages: solving the UI inconstistency

### DIFF
--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -7,6 +7,7 @@ export const SmartProxyApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: BASE_URL,
   }),
+  refetchOnReconnect: true,
   endpoints: (builder) => ({
     getClusterById: builder.query({
       query: ({ id, includeDisabled }) =>
@@ -30,6 +31,7 @@ export const SmartProxyApi = createApi({
           data: response.data.filter((element) => element.cluster_id !== ''),
         };
       },
+      keepUnusedDataFor: 5,
     }),
   }),
 });

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -23,6 +23,7 @@ export const SmartProxyApi = createApi({
     }),
     getRecs: builder.query({
       query: () => `v2/rule`,
+      keepUnusedDataFor: 5,
     }),
     getClusters: builder.query({
       query: () => `v2/clusters`,


### PR DESCRIPTION
Added a parameter to the clusters page endpoint and recommendation page endpoint
Added a parameter to all smart proxy endpoints to fetch data if the user lost his internet and then got it back

Link to the RTK docs https://redux-toolkit.js.org/rtk-query/usage/cache-behavior#default-cache-behavior