### PR TITLE
fix(labels): rule details component: make labels compact

### DIFF
--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -153,10 +153,16 @@ const ClusterRules = ({ reports }) => {
                         </span>
                       }
                     >
-                      <InsightsLabel value={value.total_risk} />
+                      <InsightsLabel
+                        value={value.total_risk}
+                        rest={{ isCompact: true }}
+                      />
                     </Tooltip>
                   ) : (
-                    <InsightsLabel value={value.total_risk} />
+                    <InsightsLabel
+                      value={value.total_risk}
+                      rest={{ isCompact: true }}
+                    />
                   )}
                 </div>
               ),

--- a/src/Components/RuleDetailsLocal/RuleDetails.js
+++ b/src/Components/RuleDetailsLocal/RuleDetails.js
@@ -116,7 +116,10 @@ const BaseRuleDetails = ({
               <StackItem className="pf-u-display-inline-flex alignCenterOverride pf-u-pb-sm pf-u-pt-sm">
                 <span className="ins-c-rule-details__stackitem">
                   <span>
-                    <InsightsLabel value={rule.total_risk} />
+                    <InsightsLabel
+                      value={rule.total_risk}
+                      rest={{ isCompact: true }}
+                    />
                   </span>
                   <Stack hasGutter className="description-stack-override">
                     <StackItem>


### PR DESCRIPTION
Make total risk label compact

![Screenshot 2022-03-09 at 16-01-47 Pods couldn't find attached VMDK on VMware node if disk EnableUUID is not set to TRUE on ](https://user-images.githubusercontent.com/31385370/157468297-78bf92aa-3b68-4937-a652-7afd8f88f51b.png)

![Screenshot 2022-03-09 at 16-01-39 Recommendations - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/157468300-547b44c2-ddd8-46d4-9544-737a9887e74b.png)
