### PR TITLE
fix: keep original order of entities in all tables

### DIFF
--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -182,14 +182,12 @@ const ClusterRules = ({ reports }) => {
   const buildDisplayedRows = (rows, index, direction) => {
     let sortingRows = [...rows];
     if (index >= 0) {
+      const d = direction === SortByDirection.asc ? 1 : -1;
       sortingRows = [...rows].sort((firstItem, secondItem) => {
         const fst = firstItem[0].rule[CLUSTER_RULES_COLUMNS_KEYS[index - 1]];
         const snd = secondItem[0].rule[CLUSTER_RULES_COLUMNS_KEYS[index - 1]];
-        return fst > snd ? 1 : snd > fst ? -1 : 0;
+        return fst > snd ? d : snd > fst ? -d : 0;
       });
-      if (direction === SortByDirection.desc) {
-        sortingRows.reverse();
-      }
     } else if (firstRule) {
       const i = rows.findIndex((row) => {
         const rule = row[0].rule;
@@ -212,8 +210,14 @@ const ClusterRules = ({ reports }) => {
     });
   };
 
-  const onSort = (_e, index, direction) =>
-    updateFilters({ ...filters, sortIndex: index, sortDirection: direction });
+  const onSort = (_e, index, direction) => {
+    //setExpandFirst(false);
+    return updateFilters({
+      ...filters,
+      sortIndex: index,
+      sortDirection: direction,
+    });
+  };
 
   const removeFilterParam = (param) => {
     const filter = { ...filters, offset: 0 };

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -197,6 +197,7 @@ describe('cluster rules table', () => {
     cy.get('button').contains('Reset filters').should('not.exist');
   });
 
+  // all tables must preserve original ordering
   _.zip(['description', 'created_at', 'total_risk'], TABLE_HEADERS).forEach(
     ([category, label]) => {
       SORTING_ORDERS.forEach((order) => {
@@ -210,19 +211,14 @@ describe('cluster rules table', () => {
           } else {
             cy.get(header).find('button').dblclick();
           }
-          // FIXME original order is not retained but reversed when descending
-          // let sortedDescriptions = _.map(
-          //   _.orderBy(data, [category], [(order === 'descending')? 'desc': 'asc']),
-          //   'description'
-          // );
           let sortedDescriptions = _.map(
-            _.orderBy(data, [category], ['asc']),
+            _.orderBy(
+              data,
+              [category],
+              [order === 'descending' ? 'desc' : 'asc']
+            ),
             'description'
           );
-          if (order === 'descending') {
-            sortedDescriptions = sortedDescriptions.reverse();
-          }
-
           cy.get(`td[data-label="Description"]`)
             .then(($els) => {
               return _.map(Cypress.$.makeArray($els), 'innerText');

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -482,7 +482,7 @@ describe('clusters list table', () => {
 
         // add property name to clusters
         let sortedNames = _.map(
-          // preserver original ordering
+          // all tables must preserve original ordering
           _.orderBy(
             _.cloneDeep(namedClusters),
             [category],

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -217,6 +217,7 @@ const RecsListTable = ({ query }) => {
 
   const buildDisplayedRows = (rows, index, direction) => {
     const sortingRows = [...rows].sort((firstItem, secondItem) => {
+      const d = direction === SortByDirection.asc ? 1 : -1;
       const fst = firstItem[0].rule[RECS_LIST_COLUMNS_KEYS[index - 1]];
       const snd = secondItem[0].rule[RECS_LIST_COLUMNS_KEYS[index - 1]];
       if (index === 3) {
@@ -224,11 +225,8 @@ const RecsListTable = ({ query }) => {
           extractCategories(snd)[0]
         );
       }
-      return fst > snd ? 1 : snd > fst ? -1 : 0;
+      return fst > snd ? d : snd > fst ? -d : 0;
     });
-    if (direction === SortByDirection.desc) {
-      sortingRows.reverse();
-    }
     return sortingRows
       .slice(
         filters.limit * (page - 1),

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -328,6 +328,7 @@ describe('successful non-empty recommendations list table', () => {
       .contains('Critical');
   });
 
+  // all tables must preserve original ordering
   it('can sort by category', () => {
     cy.sortByCol(2);
     cy.getAllRows()
@@ -342,7 +343,7 @@ describe('successful non-empty recommendations list table', () => {
     cy.getAllRows()
       .eq(0)
       .find('td[data-label=Category]')
-      .should('contain', 'Service Availability');
+      .should('contain', 'Performance');
   });
 
   it('the Impacted filters work correctly', () => {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-7407.

If a table is sorted and the sorted parameter is equal to some of the entities (for example, 3 rules with a Moderate total risk), their original order must be preserved in both ascending and descending sortings.