### PR TITLE
fix(tables): revert the time-based refresh feature

### DIFF
--- a/src/Components/Cluster/index.js
+++ b/src/Components/Cluster/index.js
@@ -22,6 +22,7 @@ export default routerParams(({ match }) => {
       const subnav = `${match.params.clusterId} - ${intl.formatMessage(
         messages.clusters
       )}`;
+      // FIXME: https://consoledot.pages.redhat.com/insights-chrome/dev/api.html#_using_updatedocumenttitle_function
       document.title = intl.formatMessage(messages.documentTitle, { subnav });
     }
   }, [match.params.clusterId]);

--- a/src/Components/ClustersList/index.js
+++ b/src/Components/ClustersList/index.js
@@ -11,6 +11,7 @@ import ClustersListTable from '../ClustersListTable';
 
 const ClustersList = () => {
   const intl = useIntl();
+  // FIXME: https://consoledot.pages.redhat.com/insights-chrome/dev/api.html#_using_updatedocumenttitle_function
   document.title = intl.formatMessage(messages.documentTitle, {
     subnav: 'Clusters',
   });

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -106,8 +106,6 @@ const ClustersListTable = ({
     );
   };
 
-  useEffect(() => setInterval(() => refetch(), 20000), []);
-
   const removeFilterParam = (param) => {
     const { [param]: omitted, ...newFilters } = { ...filters, offset: 0 };
     updateFilters({

--- a/src/Components/Recommendation/index.js
+++ b/src/Components/Recommendation/index.js
@@ -16,6 +16,7 @@ const RecommendationWrapper = () => {
   const ack = useGetRecAcksQuery({ ruleId: useParams().recommendationId });
   if (rule.isSuccess && rule.data?.content?.description) {
     const subnav = `${rule.data.content.description} - Recommendations`;
+    // FIXME: https://consoledot.pages.redhat.com/insights-chrome/dev/api.html#_using_updatedocumenttitle_function
     document.title = intl.formatMessage(messages.documentTitle, { subnav });
   }
   const clusters = useGetAffectedClustersQuery(useParams().recommendationId);

--- a/src/Components/RecsList/index.js
+++ b/src/Components/RecsList/index.js
@@ -15,6 +15,7 @@ const RecsListTable = lazy(() =>
 
 const RecsList = () => {
   const intl = useIntl();
+  // FIXME: https://consoledot.pages.redhat.com/insights-chrome/dev/api.html#_using_updatedocumenttitle_function
   document.title = intl.formatMessage(messages.documentTitle, {
     subnav: 'Recommendations',
   });

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -112,8 +112,6 @@ const RecsListTable = ({ query }) => {
     setFilterBuilding(false);
   }, []);
 
-  useEffect(() => setInterval(() => refetch(), 20000), []);
-
   // constructs array of rows (from the initial data) checking currently applied filters
   const buildFilteredRows = (allRows, filters) => {
     return allRows


### PR DESCRIPTION
Revert the time-based data refresh feature implemented in https://github.com/RedHatInsights/ocp-advisor-frontend/pull/177 since it breaks integration tests and requires a proper discussion.