### PR TITLE
Last seen at

### DIFF
--- a/cypress/fixtures/api/insights-results-aggregator/v2/clusters.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/clusters.json
@@ -108,9 +108,8 @@
     {
       "cluster_id": "99d8d133-e5fc-42f2-981d-d88932023e48",
       "cluster_name": "qjydd73t8 q0kx4ca95l",
-      "last_checked_at": "2020-06-07T13:13:26.063Z",
-      "total_hit_count": 20,
-      "hits_by_total_risk": { "1": 7, "2": 8, "3": 5, "4": 0 }
+      "total_hit_count": 0,
+      "hits_by_total_risk": { "1": 0, "2": 0, "3": 0, "4": 0 }
     },
     {
       "cluster_id": "a2f15021-ba2a-46a4-af1d-8966b681249d",
@@ -199,9 +198,8 @@
     {
       "cluster_id": "0abb45ac-3ade-49c7-a7d4-ec2af0ee21db",
       "cluster_name": "y7gz4faz1 k6rqb02yo",
-      "last_checked_at": "",
-      "total_hit_count": 13,
-      "hits_by_total_risk": { "1": 2, "2": 3, "3": 5, "4": 3 }
+      "total_hit_count": 0,
+      "hits_by_total_risk": { "1": 0, "2": 0, "3": 0, "4": 0 }
     }
   ],
   "meta": {

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -55,10 +55,15 @@ function checkRowCounts(tableLocator, n) {
   return cy.get(tableLocator).find(TBODY).find(ROW).should('have.length', n);
 }
 
+function columnName2UrlParam(name) {
+  return name.toLowerCase().replace(/ /g, '_');
+}
+
 export {
   checkTableHeaders,
   checkPaginationTotal,
   checkPaginationValues,
   changePagination,
   checkRowCounts,
+  columnName2UrlParam,
 };

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -89,6 +89,7 @@ describe('test data', () => {
       expect(arr).to.include('not existing cluster');
     });
   });
+  // TODO is this possible?
   it('has at least one entry with N/A time', () => {
     cy.wrap(_.filter(data['enabled'], (it) => it['last_checked_at'] === ''))
       .its('length')

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -78,7 +78,7 @@ describe('test data', () => {
       expect(arr).to.include('not existing cluster');
     });
   });
-  // TODO is this possible?
+  // TODO last_check_at cannot be empty. Update/remove the test and update the data file
   it('has at least one entry with N/A time', () => {
     cy.wrap(_.filter(data['enabled'], (it) => it['last_checked_at'] === ''))
       .its('length')

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -47,7 +47,7 @@ namedClusters.forEach((it) => {
 // default sorting
 let namedClustersDefaultSorting = _.orderBy(
   namedClusters,
-  ['last_checked_at'],
+  [(it) => it.last_checked_at || '1970-01-01T01:00:00.001Z'],
   ['desc']
 );
 
@@ -117,7 +117,7 @@ describe('data', () => {
       .should('be.gte', 1);
   });
   it('at least one entry does not have last seen', () => {
-    cy.wrap(_.filter(data, (it) => it.last_checked_at === ''))
+    cy.wrap(_.filter(data, (it) => it.last_checked_at === undefined))
       .its('length')
       .should('be.gte', 1);
   });
@@ -343,7 +343,10 @@ describe('clusters list table', () => {
             cy.get(header).find('button').dblclick();
           }
 
-          // TODO is N/A mapping needed as is AffectedClustersTable?
+          // map missing last_check_at to old times
+          if (category === 'last_checked_at') {
+            category = (it) => it.last_checked_at || '1970-01-01T01:00:00.001Z';
+          }
 
           // add property name to clusters
           let sortedNames = _.map(
@@ -408,7 +411,7 @@ describe('clusters list table', () => {
         .find('button')
         .click()
         .then(() => expect(window.location.search).to.contain(`limit=50`));
-      cy.getTotalClusters().should('have.text', 26);
+      cy.getTotalClusters().should('have.text', 24);
       // check all shown clusters have recommendations > 0
       cy.get('TBODY')
         .find('td[data-label=Recommendations]')

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -62,18 +62,6 @@ const TABLE_HEADERS = [
   'Low',
   'Last seen',
 ];
-// TODO check if there is a simple conversion for this
-// lowercase and replace spaces with _
-// whould that make sense?
-const TABLE_HEADERS_SORT_KEYS = {
-  Name: 'name',
-  Recommendations: 'recommendations',
-  Critical: 'critical',
-  Important: 'important',
-  Moderate: 'moderate',
-  Low: 'low',
-  'Last seen': 'last_seen',
-};
 
 // FIXME improve syntax
 // FIXME move to utils module

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -65,6 +65,11 @@ const TABLE_HEADERS = [
   'Last seen',
 ];
 
+// TODO move sw else? Also useful for other modules
+function columnName2UrlParam(name) {
+  return name.toLowerCase().replace(/ /g, '_');
+}
+
 // TODO: test pre-filled search parameters filtration
 
 describe('data', () => {

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -27,6 +27,7 @@ import {
   checkRowCounts,
   checkPaginationValues,
   changePagination,
+  columnName2UrlParam,
 } from '../../../cypress/utils/table';
 
 const data = props['data'];
@@ -253,58 +254,6 @@ describe('clusters list table', () => {
   });
 
   describe('sorting', () => {
-    // TODO check duplicated
-    // TODO do not use hardcoded values
-    it('can sort by columns', () => {
-      // check initial state
-      cy.getFirstRow()
-        .find('td[data-label=Name]')
-        .should('have.text', '947b8f15-cc44-47ca-9265-945085d4f3b8');
-      // click on the Name sorting button
-      cy.get('.pf-c-table__sort')
-        .eq(0)
-        .click()
-        .then(() => expect(window.location.search).to.contain(`sort=name`));
-      cy.getFirstRow()
-        .find('td[data-label=Name]')
-        .should('have.text', '1ghhxwjfoi 5b5hbyv07');
-      // click on the Recommendations sorting button
-      cy.get('.pf-c-table__sort')
-        .eq(1)
-        .click()
-        .then(() =>
-          expect(window.location.search).to.contain(`sort=recommendations`)
-        );
-      // the first cluster has 0 recommendations
-      cy.getFirstRow()
-        .find('td[data-label=Recommendations]')
-        .should('have.text', 0);
-    });
-
-    // TODO check duplicated
-    it('sorts N/A in last seen correctly', () => {
-      cy.get('.pf-c-table__sort')
-        .eq(6)
-        .click()
-        .then(() =>
-          expect(window.location.search).to.contain(`sort=last_seen`)
-        );
-      cy.getFirstRow().find('span').should('have.text', 'N/A');
-      cy.get('.pf-c-table__sort').eq(6).click();
-      cy.get(PAGINATION)
-        .eq(0)
-        .find('.pf-c-options-menu__toggle-button')
-        .click();
-      cy.get(PAGINATION)
-        .eq(0)
-        .find('.pf-c-options-menu')
-        .find('li')
-        .eq(2)
-        .find('button')
-        .click();
-      cy.getLastRow().find('span').should('have.text', 'N/A');
-    });
-
     _.zip(
       [
         'name',
@@ -331,16 +280,19 @@ describe('clusters list table', () => {
               .find('button')
               .click()
               .then(() =>
-                // TODO is needed to have it nested?
-                // TODO why only on ascending?
                 expect(window.location.search).to.contain(
-                  `sort=${order === 'descending' ? '-' : ''}${
-                    TABLE_HEADERS_SORT_KEYS[label]
-                  }`
+                  `sort=${columnName2UrlParam(label)}`
                 )
               );
           } else {
-            cy.get(header).find('button').dblclick();
+            cy.get(header)
+              .find('button')
+              .dblclick()
+              .then(() =>
+                expect(window.location.search).to.contain(
+                  `sort=-${columnName2UrlParam(label)}`
+                )
+              );
           }
 
           // map missing last_check_at to old times


### PR DESCRIPTION
- remove `last_checked_at` when empty for /clusters endpoint to match actual behavior
- remove duplicated sorting related tests in ClustersListTable