### PR TITLE
fix(ClusterRules): Open rows memorization 

### DIFF
--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -127,11 +127,9 @@ const ClusterRules = ({ cluster }) => {
       .map((value, key) => [
         {
           rule: value,
-          isOpen: isAllExpanded
-            ? true
-            : value?.rule_id === recordExpanded.includes(value?.rule_id)
-            ? true
-            : false,
+          isOpen:
+            isAllExpanded ||
+            value?.rule_id === recordExpanded.includes(value?.rule_id),
           cells: [
             {
               title: (
@@ -224,6 +222,7 @@ const ClusterRules = ({ cluster }) => {
     }
     return sortingRows.flatMap((row, index) => {
       const updatedRow = [...row];
+      console.log(row);
       if (recordExpanded.includes(row[0].rule.rule_id)) {
         row[0].isOpen = true;
       }
@@ -384,6 +383,9 @@ const ClusterRules = ({ cluster }) => {
   //Used in the PrimaryToolbar
   const collapseAll = (_e, isOpen) => {
     setIsAllExpanded(isOpen);
+    if (!isAllExpanded) {
+      setRecordExpanded([]);
+    }
     setDisplayedRows(
       displayedRows.map((row) => {
         return {

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -119,16 +119,18 @@ const ClusterRules = ({ cluster }) => {
   };
 
   const buildFilteredRows = (allRows, filters) => {
-    const expandedRows = displayedRows
-      .filter((ruleExpanded) => ruleExpanded?.isOpen === true)
-      .flatMap((object) => [object?.rule?.rule_id]);
+    const expandedRowsSet = new Set(
+      displayedRows
+        .filter((ruleExpanded) => ruleExpanded?.isOpen)
+        .map((object) => object?.rule?.rule_id)
+    );
 
     return allRows
       .filter((rule) => passFilters(rule, filters))
       .map((value, key) => [
         {
           rule: value,
-          isOpen: isAllExpanded || expandedRows?.includes(value?.rule_id),
+          isOpen: isAllExpanded || expandedRowsSet?.has(value?.rule_id),
           cells: [
             {
               title: (

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -231,6 +231,7 @@ const ClusterRules = ({ cluster }) => {
   };
 
   const onSort = (_e, index, direction) => {
+    setExpandFirst(false);
     setFirstRule('');
     return updateFilters({
       ...filters,

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -186,9 +186,9 @@ describe('cluster rules table', () => {
   });
 
   describe('defaults', () => {
-    it('no expanded rows', () => {
+    it('only one row is expanded', () => {
       cy.get('#expanded-content1').should('have.length', 1);
-      cy.get(EXPANDABLES).should('have.length', 0);
+      cy.get(EXPANDABLES).should('have.length', 1);
     });
     it('no chips are displayed by default', () => {
       cy.get(CHIP_GROUP).should('not.exist');
@@ -208,13 +208,13 @@ describe('cluster rules table', () => {
   });
 
   it('expand one row then sort', () => {
-    cy.get(ROOT).find('#expandable-toggle0').click();
+    cy.get(ROOT).find('#expandable-toggle2').click();
     cy.get(ROOT)
       .find('th[data-label=Description]')
       .find('button')
       .click()
       .click();
-    cy.get('table').find('tr').find('td[id="expanded-content11"]');
+    cy.get(EXPANDABLES).should('have.length', 2);
   });
 
   describe('sorting', () => {

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -186,9 +186,9 @@ describe('cluster rules table', () => {
   });
 
   describe('defaults', () => {
-    it('only first item expanded', () => {
+    it('no expanded rows', () => {
       cy.get('#expanded-content1').should('have.length', 1);
-      cy.get(EXPANDABLES).should('have.length', 1);
+      cy.get(EXPANDABLES).should('have.length', 0);
     });
     it('no chips are displayed by default', () => {
       cy.get(CHIP_GROUP).should('not.exist');

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -207,7 +207,7 @@ describe('cluster rules table', () => {
     cy.get(EXPANDABLES).should('have.length', 0);
   });
 
-  it.only('expand one row then sort', () => {
+  it('expand one row then sort', () => {
     cy.get(ROOT).find('#expandable-toggle0').click();
     cy.get(ROOT)
       .find('th[data-label=Description]')

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -207,6 +207,16 @@ describe('cluster rules table', () => {
     cy.get(EXPANDABLES).should('have.length', 0);
   });
 
+  it.only('expand one row then sort', () => {
+    cy.get(ROOT).find('#expandable-toggle0').click();
+    cy.get(ROOT)
+      .find('th[data-label=Description]')
+      .find('button')
+      .click()
+      .click();
+    cy.get('table').find('tr').find('td[id="expanded-content11"]');
+  });
+
   describe('sorting', () => {
     // all tables must preserve original ordering
     _.zip(['description', 'created_at', 'total_risk'], TABLE_HEADERS).forEach(


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-7900.

Recording the opened rows for the single cluster page
Fixed the test

The expand collapse behavior:
1)When the user opens the page for the first time - the first row is expanded
2)If he clicks sort after that, only the rows that were expanded will stay that way
if he expands several different rows\all rows before that -> only these rows will stay expanded