### PR TITLE
fix(Cluster rules table): display table rows only when filtering is completed

### DIFF
--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -7,14 +7,13 @@ import { Cluster } from './Cluster';
 import { Provider } from 'react-redux';
 import getStore from '../../Store';
 import singleClusterPageReport from '../../../cypress/fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/reports-disabled-false.json';
+import { checkRowCounts } from '../../../cypress/utils/table';
 
 // selectors
 const CLUSTER_HEADER = '#cluster-header';
 const BREADCRUMBS = 'nav[class=pf-c-breadcrumb]';
 const RULES_TABLE = '#cluster-recs-list-table';
 const FILTER_CHIPS = 'li[class=pf-c-chip-group__list-item]';
-const ROW = 'tbody[role=rowgroup]';
-Cypress.Commands.add('getAllRows', () => cy.get(RULES_TABLE).find(ROW));
 let props;
 
 describe('cluster page', () => {
@@ -63,11 +62,7 @@ describe('cluster page', () => {
     // renders table component
     cy.get(RULES_TABLE).should('have.length', 1);
     // test how many rows were rendered
-    // TODO use checkRowCounts (currently not working, probably related to federated modules)
-    cy.getAllRows().should(
-      'have.length',
-      singleClusterPageReport.report.data.length
-    );
+    checkRowCounts(singleClusterPageReport.report.data.length);
   });
 
   it('cluster page in the loading state', () => {
@@ -143,7 +138,7 @@ describe('cluster page', () => {
     cy.get(FILTER_CHIPS).each(($el) =>
       expect($el.text()).to.be.oneOf(['foo bar', 'Low', 'Performance'])
     );
-    cy.getAllRows().should('have.length', 1);
+    checkRowCounts(0);
   });
 
   it('adds additional filters passed by the query parameters №2', () => {
@@ -166,7 +161,7 @@ describe('cluster page', () => {
         'Service Availability',
       ])
     );
-    cy.getAllRows().should('have.length', 1);
+    checkRowCounts(0);
   });
 });
 

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -70,30 +70,11 @@ const ClusterRules = ({ cluster }) => {
   const [firstRule, setFirstRule] = useState(''); // show a particular rule first
   const results = filteredRows.length;
   const { search } = useLocation();
-  // helps to distinguish the state when the API data received but not yet filtered
+  const [rowsUpdating, setRowsUpdating] = useState(true);
   const [rowsFiltered, setRowsFiltered] = useState(false);
-  const loadingState = isUninitialized || isFetching || !rowsFiltered;
+  const loadingState = isUninitialized || isFetching || rowsUpdating;
   const errorState = isError;
   const successState = isSuccess;
-
-  useEffect(() => {
-    setDisplayedRows(
-      buildDisplayedRows(filteredRows, filters.sortIndex, filters.sortDirection)
-    );
-  }, [
-    filteredRows,
-    filters.limit,
-    filters.offset,
-    filters.sortIndex,
-    filters.sortDirection,
-  ]);
-
-  useEffect(() => {
-    setFilteredRows(buildFilteredRows(reports, filters));
-    if (isSuccess && !rowsFiltered) {
-      setRowsFiltered(true);
-    }
-  }, [reports, filters]);
 
   useEffect(() => {
     if (search) {
@@ -112,6 +93,29 @@ const ClusterRules = ({ cluster }) => {
       updateFilters({ ...filters, ...paramsObject });
     }
   }, []);
+
+  useEffect(() => {
+    setFilteredRows(buildFilteredRows(reports, filters));
+  }, [reports, filters]);
+
+  useEffect(() => {
+    setDisplayedRows(
+      buildDisplayedRows(filteredRows, filters.sortIndex, filters.sortDirection)
+    );
+    setRowsFiltered(true);
+  }, [
+    filteredRows,
+    filters.limit,
+    filters.offset,
+    filters.sortIndex,
+    filters.sortDirection,
+  ]);
+
+  useEffect(() => {
+    if (rowsFiltered) {
+      setRowsUpdating(false);
+    }
+  }, [rowsFiltered]);
 
   const handleOnCollapse = (_e, rowId, isOpen) => {
     const collapseRows = [...displayedRows];


### PR DESCRIPTION
The bug was discovered when the cypress rows counting test was failing (for a manual test, the bug is not visible, however, automated tests are able to identify them since they manipulate with interface way faster than users). 

This makes the table show rows only when the data filtering and sorting are complete.