### PR TITLE
Render cluster version in the affected clusters table

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -28,7 +28,8 @@
   "errorStateTitle": "Something went wrong",
   "faultTolerance": "Fault Tolerance",
   "feedbackThankyou": "Thank you for your feedback!",
-  "filterBy": "Filter by name",
+  "filterByName": "Filter by name",
+  "filterByVersion": "Filter by version",
   "high": "High",
   "hostAckModalTitle": "Recommendation has been disabled for:",
   "impact": "Impact",
@@ -107,6 +108,7 @@
   "unableToConnectDesc": "There was an error retrieving data. Check your connection and try again.",
   "undefined": "Undefined",
   "unknown": "Unknown",
+  "version": "Version",
   "veryLow": "Very Low",
   "viewAffectedClusters": "View {clusters, plural, one {the affected cluster} other {# affected clusters}}",
   "viewClusters": "View clusters"

--- a/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
@@ -38,7 +38,7 @@
         "cluster_name": "",
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
-          "cluster_version": "4.18.14"
+          "cluster_version": "4.17.9"
         }
       },
       {
@@ -86,7 +86,7 @@
         "cluster_name": "custom cluster name 2",
         "last_checked_at": "2020-11-07T08:32:37.690Z",
         "meta": {
-          "cluster_version": ""
+          "cluster_version": "4.18.12"
         }
       },
       {
@@ -94,7 +94,7 @@
         "cluster_name": "Cluster C",
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
-          "cluster_version": "4.19.15"
+          "cluster_version": "4.18.12"
         }
       },
       {

--- a/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
@@ -1,41 +1,190 @@
 {
   "data": {
     "enabled": [
-      { "cluster": "694d3942-9cb7-42b8-aad2-1f28cc7f0a3b", "cluster_name": "","last_checked_at": "2020-02-22T08:32:37.690Z" },
-    { "cluster": "bcbd9c24-bf3f-4141-9a6c-019f5404164e", "cluster_name": "","last_checked_at": "2020-02-22T08:32:37.690Z" },
-    {
-      "cluster": "685de527-ad9e-426c-a83f-07d797dd28e8",
-      "cluster_name": "foobar cluster",
-      "last_checked_at": "2022-05-22T08:32:37.690Z"
-    },
-    { "cluster": "4bc920df-7935-4882-a946-e1e735439620", "cluster_name": "","last_checked_at": "2020-02-22T08:32:37.690Z" },
-    { "cluster": "41c30565-b4c9-49f2-a4ce-3277ad22b258", "cluster_name": "","last_checked_at": "2020-02-22T08:32:37.690Z" },
-    {
-      "cluster": "6810f59e-c37c-420a-ae52-c23ccaccffc9",
-      "cluster_name": "custom cluster name 1",
-      "last_checked_at": "2021-04-02T08:32:37.690Z"
-    },
-    { "cluster": "5d5892d3-1f74-4ccf-22af-548dfc9767bb", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "444cf4e5-a983-4894-9852-cb8b441b7006", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "00d404e4-9e83-46ee-9ddd-83c06fa65d67", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "e73ee8b2-f60f-4bb0-abc7-be3093debfe7", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    {
-      "cluster": "f7331e9a-2f59-484d-af52-338d56165df5",
-      "cluster_name": "custom cluster name 2",
-      "last_checked_at": "2020-11-07T08:32:37.690Z"
-    },
-    { "cluster": "56f646b2-cf9f-46b2-9553-0e399465b966", "cluster_name": "Cluster C","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "e508506a-6cac-4925-9582-fdc0338e1020", "cluster_name": "Cluster C","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "bb7c5181-5464-4979-90de-135e38c8794a", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "6367317a-5ffe-472c-a9dc-70d8a67485b4", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "a7fc5b1a-d3f3-4103-91d3-f1cf560a1910", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "40dbef1f-0382-4342-8e4e-c2bf299928c5", "cluster_name": "","last_checked_at": "2021-07-16T12:00:00Z" },
-    { "cluster": "96c55abf-db62-4e99-b01a-9331a757097f", "cluster_name": "","last_checked_at": "2021-01-11T16:00:00Z" },
-    { "cluster": "dd2ef343-9131-46f5-8962-290fdfdf2199", "cluster_name": "","last_checked_at": "2021-10-17T15:00:00Z" },
-    { "cluster": "90f9a6ea-f79a-4d8d-a889-f0fb151aca5e", "cluster_name": "","last_checked_at": "2021-04-08T20:35:32.798Z" },
-    { "cluster": "ff41a4ee-aa2c-43a2-ac65-d5956252416d", "cluster_name": "","last_checked_at": "2020-02-22T08:32:37.690Z" },
-    { "cluster": "020cc0a1-6f1a-45fa-9780-3f4e74590902", "cluster_name": "","last_checked_at": "2020-02-22T08:32:37.690Z" },
-    { "cluster": "75400997-78fe-404e-a900-1c630bc3501d", "cluster_name": "","last_checked_at": "2020-02-22T08:32:37.690Z" }
+      {
+        "cluster": "694d3942-9cb7-42b8-aad2-1f28cc7f0a3b",
+        "cluster_name": "",
+        "last_checked_at": "2020-02-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "3.0.3"
+        }
+      },
+      {
+        "cluster": "bcbd9c24-bf3f-4141-9a6c-019f5404164e",
+        "cluster_name": "",
+        "last_checked_at": "2020-02-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "4.17.9"
+        }
+      },
+      {
+        "cluster": "685de527-ad9e-426c-a83f-07d797dd28e8",
+        "cluster_name": "foobar cluster",
+        "last_checked_at": "2022-05-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": ""
+        }
+      },
+      {
+        "cluster": "4bc920df-7935-4882-a946-e1e735439620",
+        "cluster_name": "",
+        "last_checked_at": "2020-02-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "3.3.5"
+        }
+      },
+      {
+        "cluster": "41c30565-b4c9-49f2-a4ce-3277ad22b258",
+        "cluster_name": "",
+        "last_checked_at": "2020-02-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "4.18.14"
+        }
+      },
+      {
+        "cluster": "6810f59e-c37c-420a-ae52-c23ccaccffc9",
+        "cluster_name": "custom cluster name 1",
+        "last_checked_at": "2021-04-02T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "4.11.16"
+        }
+      },
+      {
+        "cluster": "5d5892d3-1f74-4ccf-22af-548dfc9767bb",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.8.2"
+        }
+      },
+      {
+        "cluster": "444cf4e5-a983-4894-9852-cb8b441b7006",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": ""
+        }
+      },
+      {
+        "cluster": "00d404e4-9e83-46ee-9ddd-83c06fa65d67",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.9.5"
+        }
+      },
+      {
+        "cluster": "e73ee8b2-f60f-4bb0-abc7-be3093debfe7",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.18.12"
+        }
+      },
+      {
+        "cluster": "f7331e9a-2f59-484d-af52-338d56165df5",
+        "cluster_name": "custom cluster name 2",
+        "last_checked_at": "2020-11-07T08:32:37.690Z",
+        "meta": {
+          "cluster_version": ""
+        }
+      },
+      {
+        "cluster": "56f646b2-cf9f-46b2-9553-0e399465b966",
+        "cluster_name": "Cluster C",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.19.15"
+        }
+      },
+      {
+        "cluster": "e508506a-6cac-4925-9582-fdc0338e1020",
+        "cluster_name": "Cluster C",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.6.13"
+        }
+      },
+      {
+        "cluster": "bb7c5181-5464-4979-90de-135e38c8794a",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.5.0"
+        }
+      },
+      {
+        "cluster": "6367317a-5ffe-472c-a9dc-70d8a67485b4",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.12.8"
+        }
+      },
+      {
+        "cluster": "a7fc5b1a-d3f3-4103-91d3-f1cf560a1910",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "4.1.7"
+        }
+      },
+      {
+        "cluster": "40dbef1f-0382-4342-8e4e-c2bf299928c5",
+        "cluster_name": "",
+        "last_checked_at": "2021-07-16T12:00:00Z",
+        "meta": {
+          "cluster_version": "4.9.3"
+        }
+      },
+      {
+        "cluster": "96c55abf-db62-4e99-b01a-9331a757097f",
+        "cluster_name": "",
+        "last_checked_at": "2021-01-11T16:00:00Z",
+        "meta": {
+          "cluster_version": ""
+        }
+      },
+      {
+        "cluster": "dd2ef343-9131-46f5-8962-290fdfdf2199",
+        "cluster_name": "",
+        "last_checked_at": "2021-10-17T15:00:00Z",
+        "meta": {
+          "cluster_version": "4.1.18"
+        }
+      },
+      {
+        "cluster": "90f9a6ea-f79a-4d8d-a889-f0fb151aca5e",
+        "cluster_name": "",
+        "last_checked_at": "2021-04-08T20:35:32.798Z",
+        "meta": {
+          "cluster_version": "3.13.17"
+        }
+      },
+      {
+        "cluster": "ff41a4ee-aa2c-43a2-ac65-d5956252416d",
+        "cluster_name": "",
+        "last_checked_at": "2020-02-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "4.14.14"
+        }
+      },
+      {
+        "cluster": "020cc0a1-6f1a-45fa-9780-3f4e74590902",
+        "cluster_name": "",
+        "last_checked_at": "2020-02-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "3.7.15"
+        }
+      },
+      {
+        "cluster": "75400997-78fe-404e-a900-1c630bc3501d",
+        "cluster_name": "",
+        "last_checked_at": "2020-02-22T08:32:37.690Z",
+        "meta": {
+          "cluster_version": "4.9.14"
+        }
+      }
     ],
     "disabled": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "react-redux": "8.0.1",
         "react-router-dom": "5.3.1",
         "redux": "4.2.0",
-        "redux-logger": "3.0.6"
+        "redux-logger": "3.0.6",
+        "semver": "^6.3.0"
       },
       "devDependencies": {
         "@babel/core": "7.17.9",
@@ -5374,6 +5375,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -5389,7 +5392,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -32760,15 +32765,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -32780,7 +32784,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "react-redux": "8.0.1",
     "react-router-dom": "5.3.1",
     "redux": "4.2.0",
-    "redux-logger": "3.0.6"
+    "redux-logger": "3.0.6",
+    "semver": "^6.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.17.9",

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -254,12 +254,17 @@ export const RECS_LIST_COLUMNS_KEYS = [
   'total_risk',
   'impacted_clusters_count',
 ];
-export const AFFECTED_CLUSTERS_NAME_CELL = 1;
-export const AFFECTED_CLUSTERS_LAST_SEEN = 2;
+export const AFFECTED_CLUSTERS_NAME_CELL = 0;
+export const AFFECTED_CLUSTERS_VERSION_CELL = 1;
+export const AFFECTED_CLUSTERS_LAST_SEEN_CELL = 2;
 export const AFFECTED_CLUSTERS_COLUMNS = [
   {
     title: intl.formatMessage(messages.name),
-    transforms: [sortable, cellWidth(80)],
+    transforms: [sortable, cellWidth(60)],
+  },
+  {
+    title: intl.formatMessage(messages.version),
+    transforms: [cellWidth(20)],
   },
   {
     title: intl.formatMessage(messages.lastSeen),

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -264,7 +264,7 @@ export const AFFECTED_CLUSTERS_COLUMNS = [
   },
   {
     title: intl.formatMessage(messages.version),
-    transforms: [cellWidth(20)],
+    transforms: [sortable, cellWidth(20)],
   },
   {
     title: intl.formatMessage(messages.lastSeen),

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -254,9 +254,9 @@ export const RECS_LIST_COLUMNS_KEYS = [
   'total_risk',
   'impacted_clusters_count',
 ];
-export const AFFECTED_CLUSTERS_NAME_CELL = 0;
-export const AFFECTED_CLUSTERS_VERSION_CELL = 1;
-export const AFFECTED_CLUSTERS_LAST_SEEN_CELL = 2;
+export const AFFECTED_CLUSTERS_NAME_CELL = 1;
+export const AFFECTED_CLUSTERS_VERSION_CELL = 2;
+export const AFFECTED_CLUSTERS_LAST_SEEN_CELL = 3;
 export const AFFECTED_CLUSTERS_COLUMNS = [
   {
     title: intl.formatMessage(messages.name),

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -260,15 +260,15 @@ export const AFFECTED_CLUSTERS_LAST_SEEN_CELL = 3;
 export const AFFECTED_CLUSTERS_COLUMNS = [
   {
     title: intl.formatMessage(messages.name),
-    transforms: [sortable, cellWidth(60)],
+    transforms: [sortable, cellWidth(70)],
   },
   {
     title: intl.formatMessage(messages.version),
-    transforms: [sortable, cellWidth(20)],
+    transforms: [sortable, cellWidth(15)],
   },
   {
     title: intl.formatMessage(messages.lastSeen),
-    transforms: [sortable, cellWidth(20)],
+    transforms: [sortable, cellWidth(15)],
   },
 ];
 // TODO: remove since unused

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -271,6 +271,7 @@ export const AFFECTED_CLUSTERS_COLUMNS = [
     transforms: [sortable, cellWidth(20)],
   },
 ];
+// TODO: remove since unused
 export const DEBOUNCE_DELAY = 600;
 export const CLUSTER_RULES_COLUMNS_KEYS = [
   '', // reserved for expand button

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -40,7 +40,11 @@ import {
 } from '../../Services/Filters';
 import messages from '../../Messages';
 import DisableRule from '../Modals/DisableRule';
-import { buildFilterChips, compareSemVer } from '../Common/Tables';
+import {
+  buildFilterChips,
+  compareSemVer,
+  removeFilterParam as _removeFilterParam,
+} from '../Common/Tables';
 
 const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   const intl = useIntl();
@@ -70,6 +74,9 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
 
   const updateFilters = (filters) =>
     dispatch(updateAffectedClustersFilters(filters));
+
+  const removeFilterParam = (param) =>
+    _removeFilterParam(filters, updateFilters, param);
 
   const filterConfig = {
     items: [
@@ -239,18 +246,6 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   const handleModalToggle = (disableRuleModalOpen, host = undefined) => {
     setDisableRuleModalOpen(disableRuleModalOpen);
     setHost(host);
-  };
-
-  const removeFilterParam = (param) => {
-    const { [param]: omitted, ...newFilters } = { ...filters, offset: 0 };
-    updateFilters({
-      ...newFilters,
-      ...(param === 'text'
-        ? { text: '' }
-        : param === 'version'
-        ? { version: [] }
-        : {}),
-    });
   };
 
   const addFilterParam = (param, values) => {

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { valid } from 'semver';
+import uniqBy from 'lodash/uniqBy';
 
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter/conditionalFilterConstants';
 import PrimaryToolbar from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
@@ -105,15 +106,16 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
           key: 'version-filter',
           onChange: (event, value) => addFilterParam('version', value),
           value: filters.version,
-          items: rows
-            .filter((r) => r.meta.cluster_version !== '')
-            .sort((a, b) =>
-              compareSemVer(a.meta.cluster_version, b.meta.cluster_version, 1)
-            )
-            .reverse() // should start from the latest version
-            .map((r) => ({
-              value: r.meta.cluster_version,
-            })),
+          items: uniqBy(
+            rows
+              .filter((r) => r.meta.cluster_version !== '')
+              .map((r) => ({
+                value: r.meta.cluster_version,
+              }))
+              .sort((a, b) => compareSemVer(a.value, b.value, 1))
+              .reverse(), // should start from the latest version
+            'value'
+          ),
         },
       },
     ],

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -44,6 +44,7 @@ import {
   buildFilterChips,
   compareSemVer,
   removeFilterParam as _removeFilterParam,
+  addFilterParam as _addFilterParam,
 } from '../Common/Tables';
 
 const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
@@ -77,6 +78,9 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
 
   const removeFilterParam = (param) =>
     _removeFilterParam(filters, updateFilters, param);
+
+  const addFilterParam = (param, values) =>
+    _addFilterParam(filters, updateFilters, param, values);
 
   const filterConfig = {
     items: [
@@ -246,12 +250,6 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   const handleModalToggle = (disableRuleModalOpen, host = undefined) => {
     setDisableRuleModalOpen(disableRuleModalOpen);
     setHost(host);
-  };
-
-  const addFilterParam = (param, values) => {
-    values.length > 0
-      ? updateFilters({ ...filters, offset: 0, ...{ [param]: values } })
-      : removeFilterParam(param);
   };
 
   return (

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -71,7 +71,8 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   const filters = useSelector(({ filters }) => filters.affectedClustersState);
   const perPage = filters.limit;
   const page = filters.offset / filters.limit + 1;
-  const allSelected = selected.length === filteredRows.length;
+  const allSelected =
+    filteredRows.length !== 0 && selected.length === filteredRows.length;
 
   const updateFilters = (filters) =>
     dispatch(updateAffectedClustersFilters(filters));

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -132,6 +132,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
     const rows = allRows.map((r) => ({
       id: r.cluster,
       cells: [
+        '', // left intentionally because checkboxes create the 0th column
         r.cluster_name || r.cluster,
         r.meta.cluster_version,
         r.last_checked_at,
@@ -139,17 +140,24 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
     }));
     return rows
       .filter((row) => {
-        return row?.cells[0].toLowerCase().includes(filters.text.toLowerCase());
+        return row?.cells[AFFECTED_CLUSTERS_NAME_CELL].toLowerCase().includes(
+          filters.text.toLowerCase()
+        );
       })
       .sort((a, b) => {
         let fst, snd;
         const d = filters.sortDirection === 'asc' ? 1 : -1;
-        switch (filters.sortIndex - 1) {
+        console.log(filters.sortIndex);
+        switch (filters.sortIndex) {
           case AFFECTED_CLUSTERS_NAME_CELL:
             if (filters.sortDirection === 'asc') {
-              return a?.cells[0].localeCompare(b?.cells[0]);
+              return a?.cells[AFFECTED_CLUSTERS_NAME_CELL].localeCompare(
+                b?.cells[AFFECTED_CLUSTERS_NAME_CELL]
+              );
             }
-            return b?.cells[0].localeCompare(a?.cells[0]);
+            return b?.cells[AFFECTED_CLUSTERS_NAME_CELL].localeCompare(
+              a?.cells[AFFECTED_CLUSTERS_NAME_CELL]
+            );
           case AFFECTED_CLUSTERS_LAST_SEEN_CELL:
             fst = new Date(a.cells[AFFECTED_CLUSTERS_LAST_SEEN_CELL] || 0);
             snd = new Date(b.cells[AFFECTED_CLUSTERS_LAST_SEEN_CELL] || 0);

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -357,6 +357,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
         <TableHeader />
         {(isUninitialized || isFetching) && <Loading />}
         {isError && (
+          // TODO: fix crooked message container
           <Card id="error-state-message" ouiaId="error-state">
             <CardBody>
               <ErrorState />
@@ -364,6 +365,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
           </Card>
         )}
         {isSuccess && rows.length === 0 && (
+          // TODO: fix crooked message container
           <Card id="empty-state-message" ouiaId="empty-state">
             <CardBody>
               <NoAffectedClusters />
@@ -375,6 +377,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
           (filteredRows.length > 0 ? (
             <TableBody />
           ) : (
+            // TODO: fix crooked message container
             <EmptyTable>
               <Bullseye>
                 <NoMatchingClusters />

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -81,8 +81,8 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   const filterConfig = {
     items: [
       {
-        label: 'Name',
-        placeholder: 'Filter by name',
+        label: intl.formatMessage(messages.name),
+        placeholder: intl.formatMessage(messages.filterByName),
         type: conditionalFilterType.text,
         filterValues: {
           id: 'name-filter',
@@ -92,8 +92,8 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
         },
       },
       {
-        label: 'Version',
-        placeholder: 'Filter by version',
+        label: intl.formatMessage(messages.version),
+        placeholder: intl.formatMessage(messages.filterByVersion),
         type: conditionalFilterType.checkbox,
         filterValues: {
           id: 'version-filter',

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -96,6 +96,18 @@ describe('test data', () => {
       expect(arr).to.include('not existing cluster');
     });
   });
+  _.uniq(_.flatten(VERSION_COMBINATIONS)).map((c) =>
+    it(`has at least one cluster with version ${c}`, () => {
+      cy.wrap(_.filter(data, (it) => it.meta.cluster_version === c))
+        .its('length')
+        .should('be.gte', 1);
+    })
+  );
+  it(`has at least one cluster without a version`, () => {
+    cy.wrap(_.filter(data, (it) => it.meta.cluster_version === ''))
+      .its('length')
+      .should('be.gte', 1);
+  });
 });
 
 describe('non-empty successful affected clusters table', () => {
@@ -458,6 +470,7 @@ describe('non-empty successful affected clusters table', () => {
   });
 
   describe('filtering', () => {
+    // TODO: use filtersConf approach
     it('no chips are displayed by default', () => {
       cy.get(CHIP_GROUP).should('not.exist');
       cy.get('button').contains('Reset filters').should('not.exist');

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -717,8 +717,8 @@ describe('empty failed affected clusters table', () => {
   });
 
   it('renders table header', () => {
-    cy.get(TABLE).find('th').children().eq(0).should('have.text', 'Name');
-    cy.get(TABLE).find('th').children().eq(1).should('have.text', 'Version');
-    cy.get(TABLE).find('th').children().eq(2).should('have.text', 'Last seen');
+    TABLE_HEADERS.map((h, i) =>
+      cy.get(TABLE).find('th').eq(i).should('have.text', h)
+    );
   });
 });

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -387,7 +387,7 @@ describe('non-empty successful affected clusters table', () => {
 
   describe('sorting', () => {
     _.zip(
-      ['name', 'cluster_version', 'last_checked_at'],
+      ['name', 'meta.cluster_version', 'last_checked_at'],
       TABLE_HEADERS
     ).forEach(([category, label]) => {
       SORTING_ORDERS.forEach((order) => {
@@ -428,7 +428,7 @@ describe('non-empty successful affected clusters table', () => {
           }
 
           sortedClusters = _.map(
-            category === 'cluster_version'
+            category === 'meta.cluster_version'
               ? sortedClusters.sort(
                   (a, b) =>
                     (order === 'ascending' ? 1 : -1) *

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -375,7 +375,7 @@ describe('non-empty successful affected clusters table', () => {
     });
   });
 
-  describe.only('sorting', () => {
+  describe('sorting', () => {
     _.zip(
       ['name', 'cluster_version', 'last_checked_at'],
       TABLE_HEADERS
@@ -572,7 +572,7 @@ describe('non-empty successful affected clusters table', () => {
         .find(ROW)
         .first()
         .find('td')
-        .eq(3)
+        .eq(4)
         .click()
         .contains('Disable')
         .click();
@@ -663,6 +663,7 @@ describe('empty failed affected clusters table', () => {
 
   it('renders table header', () => {
     cy.get(TABLE).find('th').children().eq(0).should('have.text', 'Name');
-    cy.get(TABLE).find('th').children().eq(1).should('have.text', 'Last seen');
+    cy.get(TABLE).find('th').children().eq(1).should('have.text', 'Version');
+    cy.get(TABLE).find('th').children().eq(2).should('have.text', 'Last seen');
   });
 });

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -44,6 +44,7 @@ import { NoMatchingRecs } from '../MessageState/EmptyStates';
 import {
   paramParser,
   passFilters,
+  removeFilterParam as _removeFilterParam,
   translateSortParams,
 } from '../Common/Tables';
 import {
@@ -74,6 +75,9 @@ const ClusterRules = ({ cluster }) => {
   const loadingState = isUninitialized || isFetching || rowsUpdating;
   const errorState = isError;
   const successState = isSuccess;
+
+  const removeFilterParam = (param) =>
+    _removeFilterParam(filters, updateFilters, param);
 
   useEffect(() => {
     if (search) {
@@ -244,12 +248,6 @@ const ClusterRules = ({ cluster }) => {
       sortIndex: index,
       sortDirection: direction,
     });
-  };
-
-  const removeFilterParam = (param) => {
-    const filter = { ...filters, offset: 0 };
-    delete filter[param];
-    updateFilters({ ...filter, ...(param === 'text' ? { text: '' } : {}) });
   };
 
   // TODO: update URL when filters changed

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -45,6 +45,7 @@ import {
   paramParser,
   passFilters,
   removeFilterParam as _removeFilterParam,
+  addFilterParam as _addFilterParam,
   translateSortParams,
 } from '../Common/Tables';
 import {
@@ -78,6 +79,12 @@ const ClusterRules = ({ cluster }) => {
 
   const removeFilterParam = (param) =>
     _removeFilterParam(filters, updateFilters, param);
+
+  const addFilterParam = (param, values) => {
+    setExpandFirst(false);
+    setFirstRule('');
+    return _addFilterParam(filters, updateFilters, param, values);
+  };
 
   useEffect(() => {
     if (search) {
@@ -248,15 +255,6 @@ const ClusterRules = ({ cluster }) => {
       sortIndex: index,
       sortDirection: direction,
     });
-  };
-
-  // TODO: update URL when filters changed
-  const addFilterParam = (param, values) => {
-    setExpandFirst(false);
-    setFirstRule('');
-    return values.length > 0
-      ? updateFilters({ ...filters, offset: 0, ...{ [param]: values } })
-      : removeFilterParam(param);
   };
 
   const filterConfigItems = [

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -38,6 +38,7 @@ import {
   paramParser,
   passFiltersCluster,
   removeFilterParam as _removeFilterParam,
+  addFilterParam as _addFilterParam,
   translateSortParams,
   updateSearchParams,
 } from '../Common/Tables';
@@ -73,6 +74,9 @@ const ClustersListTable = ({
 
   const removeFilterParam = (param) =>
     _removeFilterParam(filters, updateFilters, param);
+
+  const addFilterParam = (param, values) =>
+    _addFilterParam(filters, updateFilters, param, values);
 
   useEffect(() => {
     setDisplayedRows(
@@ -152,13 +156,6 @@ const ClustersListTable = ({
       filters.limit * (page - 1),
       filters.limit * (page - 1) + filters.limit
     );
-  };
-
-  // TODO: update URL when filters changed
-  const addFilterParam = (param, values) => {
-    values.length > 0
-      ? updateFilters({ ...filters, offset: 0, ...{ [param]: values } })
-      : removeFilterParam(param);
   };
 
   const filterConfigItems = [

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -168,7 +168,7 @@ const ClustersListTable = ({
         key: 'text-filter',
         onChange: (_event, value) => updateFilters({ ...filters, text: value }),
         value: filters.text,
-        placeholder: intl.formatMessage(messages.filterBy),
+        placeholder: intl.formatMessage(messages.filterByName),
       },
     },
     {

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -37,6 +37,7 @@ import {
   mapClustersToRows,
   paramParser,
   passFiltersCluster,
+  removeFilterParam as _removeFilterParam,
   translateSortParams,
   updateSearchParams,
 } from '../Common/Tables';
@@ -69,6 +70,9 @@ const ClustersListTable = ({
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError;
   const successState = isSuccess;
+
+  const removeFilterParam = (param) =>
+    _removeFilterParam(filters, updateFilters, param);
 
   useEffect(() => {
     setDisplayedRows(
@@ -148,18 +152,6 @@ const ClustersListTable = ({
       filters.limit * (page - 1),
       filters.limit * (page - 1) + filters.limit
     );
-  };
-
-  const removeFilterParam = (param) => {
-    const { [param]: omitted, ...newFilters } = { ...filters, offset: 0 };
-    updateFilters({
-      ...newFilters,
-      ...(param === 'text'
-        ? { text: '' }
-        : param === 'hits'
-        ? { hits: [] }
-        : {}),
-    });
   };
 
   // TODO: update URL when filters changed

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -223,6 +223,7 @@ export const translateSortValue = (index, indexMapping, direction) => {
   return `${direction === 'asc' ? '' : '-'}${indexMapping[index]}`;
 };
 
+// TODO: remove since unused
 export const debounce = (value, delay) => {
   const [debouncedValue, setDebouncedValue] = useState(value);
   useEffect(() => {
@@ -258,6 +259,7 @@ export const updateSearchParams = (filters = {}, columnMapping) => {
   window.history.replaceState(null, null, url.href);
 };
 
+// TODO: move to Utils.js
 export const compareSemVer = (v1, v2, d) => d * compare(v1, v2);
 
 export const removeFilterParam = (currentFilters, updateFilters, param) => {

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import capitalize from 'lodash/capitalize';
 import cloneDeep from 'lodash/cloneDeep';
+import { compare } from 'semver';
 
 import { Tooltip } from '@patternfly/react-core/dist/js/components/Tooltip';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
@@ -160,6 +161,22 @@ const pruneFilters = (localFilters, filterCategories) => {
             ]
           : []),
       ];
+    } else if (key === 'version') {
+      return [
+        ...arr,
+        ...(item.length > 0
+          ? [
+              {
+                category: 'Version',
+                chips: item.map((it) => ({
+                  name: it,
+                  value: it,
+                })),
+                urlParam: key,
+              },
+            ]
+          : []),
+      ];
     }
   }, []);
 };
@@ -240,3 +257,5 @@ export const updateSearchParams = (filters = {}, columnMapping) => {
   });
   window.history.replaceState(null, null, url.href);
 };
+
+export const compareSemVer = (v1, v2, d) => d * compare(v1, v2);

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -259,3 +259,17 @@ export const updateSearchParams = (filters = {}, columnMapping) => {
 };
 
 export const compareSemVer = (v1, v2, d) => d * compare(v1, v2);
+
+export const removeFilterParam = (currentFilters, updateFilters, param) => {
+  const { [param]: omitted, ...newFilters } = { ...currentFilters, offset: 0 };
+  updateFilters({
+    ...newFilters,
+    ...(param === 'text'
+      ? { text: '' }
+      : param === 'hits'
+      ? { hits: [] }
+      : param === 'version'
+      ? { version: [] }
+      : {}),
+  });
+};

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -273,3 +273,12 @@ export const removeFilterParam = (currentFilters, updateFilters, param) => {
       : {}),
   });
 };
+
+export const addFilterParam = (currentFilters, updateFilters, param, values) =>
+  values.length > 0
+    ? updateFilters({
+        ...currentFilters,
+        offset: 0,
+        ...{ [param]: values },
+      })
+    : removeFilterParam(currentFilters, updateFilters, param);

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -292,7 +292,7 @@ const RecsListTable = ({ query }) => {
         onChange: (_event, value) =>
           updateFilters({ ...filters, offset: 0, text: value }),
         value: searchText,
-        placeholder: intl.formatMessage(messages.filterBy),
+        placeholder: intl.formatMessage(messages.filterByName),
       },
     },
     {

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -55,6 +55,7 @@ import {
   translateSortParams,
   updateSearchParams,
   removeFilterParam as _removeFilterParam,
+  addFilterParam as _addFilterParam,
 } from '../Common/Tables';
 import DisableRule from '../Modals/DisableRule';
 import { Delete } from '../../Utilities/Api';
@@ -95,6 +96,9 @@ const RecsListTable = ({ query }) => {
 
   const removeFilterParam = (param) =>
     _removeFilterParam(filters, updateFilters, param);
+
+  const addFilterParam = (param, values) =>
+    _addFilterParam(filters, updateFilters, param, values);
 
   useEffect(() => {
     setDisplayedRows(
@@ -270,12 +274,6 @@ const RecsListTable = ({ query }) => {
         return updatedRow;
       });
   };
-
-  // TODO: update URL when filters changed
-  const addFilterParam = (param, values) =>
-    values.length > 0
-      ? updateFilters({ ...filters, offset: 0, ...{ [param]: values } })
-      : removeFilterParam(param);
 
   const toggleRulesDisabled = (rule_status) =>
     updateFilters({

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -54,6 +54,7 @@ import {
   paramParser,
   translateSortParams,
   updateSearchParams,
+  removeFilterParam as _removeFilterParam,
 } from '../Common/Tables';
 import DisableRule from '../Modals/DisableRule';
 import { Delete } from '../../Utilities/Api';
@@ -91,6 +92,9 @@ const RecsListTable = ({ query }) => {
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError || (isSuccess && recs.length === 0);
   const successState = isSuccess && recs.length > 0;
+
+  const removeFilterParam = (param) =>
+    _removeFilterParam(filters, updateFilters, param);
 
   useEffect(() => {
     setDisplayedRows(
@@ -265,12 +269,6 @@ const RecsListTable = ({ query }) => {
         row[1].parent = index * 2;
         return updatedRow;
       });
-  };
-
-  const removeFilterParam = (param) => {
-    const filter = { ...filters, offset: 0 };
-    delete filter[param];
-    updateFilters({ ...filter, ...(param === 'text' ? { text: '' } : {}) });
   };
 
   // TODO: update URL when filters changed

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -441,6 +441,7 @@ const RecsListTable = ({ query }) => {
       : [];
   };
 
+  // TODO: use the function from Common/Tables.js
   const buildFilterChips = () => {
     const localFilters = { ...filters };
     delete localFilters.sortIndex;

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -597,4 +597,9 @@ export default defineMessages({
     description: 'Thanking user for feedback',
     defaultMessage: 'Thank you for your feedback!',
   },
+  version: {
+    id: 'version',
+    description: 'Version label name',
+    defaultMessage: 'Version',
+  },
 });

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -45,11 +45,6 @@ export default defineMessages({
     description: 'Used in the hitting rules table for the single cluster view',
     defaultMessage: 'Description',
   },
-  filterBy: {
-    id: 'filterBy',
-    description: 'Filter by name',
-    defaultMessage: 'Filter by name',
-  },
   totalRisk: {
     id: 'totalRisk',
     description:
@@ -601,5 +596,13 @@ export default defineMessages({
     id: 'version',
     description: 'Version label name',
     defaultMessage: 'Version',
+  },
+  filterByName: {
+    id: 'filterByName',
+    defaultMessage: 'Filter by name',
+  },
+  filterByVersion: {
+    id: 'filterByVersion',
+    defaultMessage: 'Filter by version',
   },
 });

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -5,7 +5,7 @@ export const AFFECTED_CLUSTERS_INITIAL_STATE = {
   limit: 20,
   offset: 0,
   text: '',
-  sortIndex: 2,
+  sortIndex: 3,
   sortDirection: null,
 };
 

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -7,6 +7,7 @@ export const AFFECTED_CLUSTERS_INITIAL_STATE = {
   text: '',
   sortIndex: 3,
   sortDirection: null,
+  version: [],
 };
 
 // recommendations list page


### PR DESCRIPTION
The PR makes the single recommendation view render the **cluster version** column. The value is contained in the API response (`GET /clusters_detail`) within the `meta.cluster_version` path.

Mocked in https://marvelapp.com/prototype/g70a1he/screen/86034747.
Implements https://issues.redhat.com/browse/CCXDEV-6435.

- [x] Render the cluster version obtained from API
- [x] Add sorting to the new column
- [x] Add the checkbox filter to the version parameter
- [x] Update tests

![Screenshot 2022-05-18 at 10-28-41 Workloads are using the deprecated PodSecurityPolicy API - Recommendations - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/168995157-774d6716-6b5c-43e6-abaa-ec053daa5a92.png)

![Screenshot 2022-05-18 at 10-29-52 Workloads are using the deprecated PodSecurityPolicy API - Recommendations - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/168995170-6e0398c9-53c4-47ce-b94c-177d2082f385.png)

![Screenshot from 2022-05-18 10-31-37](https://user-images.githubusercontent.com/31385370/168995194-dd449a77-37d7-42ff-8c56-6ea5afd6e9f3.png)

![Screenshot from 2022-05-18 10-32-01](https://user-images.githubusercontent.com/31385370/168995211-fbf1f44c-4a77-4ba4-94e1-12480c9ffb19.png)

