### PR TITLE
Display cluster version in the clusters list table

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -67,6 +67,7 @@
   "noRecsFoundError": "No recommendations to display",
   "noRecsFoundErrorDesc": "Insights identifies and prioritizes risks to security, performance, availability, and stability of your clusters. This feature uses the Remote Health functionality of OpenShift Container Platform. For further details about Insights, see the",
   "none": "None",
+  "notAvailable": "Not available",
   "oneOrMore": "1 or more",
   "performance": "Performance",
   "permsBody": "To view the content of this page, you must be granted a minimum of Advisor permissions from your Organization Administrator.",

--- a/cypress/fixtures/api/insights-results-aggregator/v2/clusters.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/clusters.json
@@ -5,201 +5,374 @@
       "cluster_name": "gvgubed6h jzcmr99ojh",
       "last_checked_at": "2021-04-08T20:35:32.798Z",
       "total_hit_count": 37,
-      "hits_by_total_risk": { "1": 8, "2": 16, "3": 9, "4": 4 }
+      "hits_by_total_risk": {
+        "1": 8,
+        "2": 16,
+        "3": 9,
+        "4": 4
+      },
+      "cluster_version": ""
     },
     {
       "cluster_id": "0abb45ac-3ade-49c7-a7d4-ec2af0ee21db",
       "cluster_name": "y7gz4faz1 k6rqb02yo",
       "last_checked_at": "2020-02-22T08:32:37.690Z",
       "total_hit_count": 13,
-      "hits_by_total_risk": { "1": 2, "2": 3, "3": 5, "4": 3 }
+      "hits_by_total_risk": {
+        "1": 2,
+        "2": 3,
+        "3": 5,
+        "4": 3
+      },
+      "cluster_version": ""
     },
     {
       "cluster_id": "689b9530-0289-4736-aced-880b1f8d59df",
       "cluster_name": "z6wp31moti 10bvba5qx",
       "last_checked_at": "2020-10-26T23:43:04.239Z",
       "total_hit_count": 15,
-      "hits_by_total_risk": { "1": 3, "2": 9, "3": 3 }
+      "hits_by_total_risk": {
+        "1": 3,
+        "2": 9,
+        "3": 3
+      },
+      "cluster_version": "4.2.24"
     },
     {
       "cluster_id": "b93b11ed-1fa6-4b23-a7f5-2557d4521d20",
       "cluster_name": "",
       "last_checked_at": "2020-08-12T19:20:20.482Z",
       "total_hit_count": 25,
-      "hits_by_total_risk": { "1": 0, "2": 19, "3": 2, "4": 4 }
+      "hits_by_total_risk": {
+        "1": 0,
+        "2": 19,
+        "3": 2,
+        "4": 4
+      },
+      "cluster_version": "4.5.4"
     },
     {
       "cluster_id": "3955ab06-88a9-4896-be0e-66de34999ec8",
       "cluster_name": "5uq3oy111 ufq7fnxcd",
       "last_checked_at": "2021-07-18T16:28:11.348Z",
       "total_hit_count": 21,
-      "hits_by_total_risk": { "1": 7, "2": 8, "3": 3, "4": 3 }
+      "hits_by_total_risk": {
+        "1": 7,
+        "2": 8,
+        "3": 3,
+        "4": 3
+      },
+      "cluster_version": ""
     },
     {
       "cluster_id": "7e4980f5-f99d-485b-9636-ac975c0ce7a1",
       "cluster_name": "",
       "last_checked_at": "2021-03-04T14:09:19.418Z",
       "total_hit_count": 19,
-      "hits_by_total_risk": { "1": 1, "2": 6, "3": 8, "4": 4 }
+      "hits_by_total_risk": {
+        "1": 1,
+        "2": 6,
+        "3": 8,
+        "4": 4
+      },
+      "cluster_version": "4.4.16"
     },
     {
       "cluster_id": "cb193f16-a894-41c0-9f30-d0539edcc762",
       "cluster_name": "",
       "last_checked_at": "2020-03-29T14:08:49.699Z",
       "total_hit_count": 18,
-      "hits_by_total_risk": { "1": 1, "2": 11, "3": 6, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 1,
+        "2": 11,
+        "3": 6,
+        "4": 0
+      },
+      "cluster_version": ""
     },
     {
       "cluster_id": "5a7810fe-7b63-4c25-85c0-20af33fcb32e",
       "cluster_name": "",
       "last_checked_at": "2021-03-18T20:30:58.839Z",
       "total_hit_count": 19,
-      "hits_by_total_risk": { "1": 6, "2": 13, "3": 0, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 6,
+        "2": 13,
+        "3": 0,
+        "4": 0
+      },
+      "cluster_version": "4.3.12"
     },
     {
       "cluster_id": "a999094d-cbf5-4105-b436-e2f6ec554fbe",
       "cluster_name": "",
       "last_checked_at": "2019-04-01T21:41:25.982Z",
       "total_hit_count": 24,
-      "hits_by_total_risk": { "1": 8, "2": 14, "3": 0, "4": 2 }
+      "hits_by_total_risk": {
+        "1": 8,
+        "2": 14,
+        "3": 0,
+        "4": 2
+      },
+      "cluster_version": "4.0.0"
     },
     {
       "cluster_id": "947b8f15-cc44-47ca-9265-945085d4f3b8",
       "cluster_name": "",
       "last_checked_at": "2021-11-27T17:32:34.063Z",
       "total_hit_count": 23,
-      "hits_by_total_risk": { "1": 5, "2": 9, "3": 7, "4": 2 }
+      "hits_by_total_risk": {
+        "1": 5,
+        "2": 9,
+        "3": 7,
+        "4": 2
+      },
+      "cluster_version": "4.6.13"
     },
     {
       "cluster_id": "cf27b922-aeb6-404f-9eba-128abdc23858",
       "cluster_name": "dxrxsrxcng 6el3om2ow",
       "last_checked_at": "2021-05-17T14:57:27.196Z",
       "total_hit_count": 20,
-      "hits_by_total_risk": { "1": 11, "2": 5, "3": 1, "4": 3 }
+      "hits_by_total_risk": {
+        "1": 11,
+        "2": 5,
+        "3": 1,
+        "4": 3
+      },
+      "cluster_version": "4.18.12"
     },
     {
       "cluster_id": "b2a968c8-aad5-4ada-886e-c97e833e918a",
       "cluster_name": "",
       "last_checked_at": "2021-05-09T21:50:04.034Z",
       "total_hit_count": 16,
-      "hits_by_total_risk": { "1": 3, "2": 6, "3": 6, "4": 1 }
+      "hits_by_total_risk": {
+        "1": 3,
+        "2": 6,
+        "3": 6,
+        "4": 1
+      },
+      "cluster_version": ""
     },
     {
       "cluster_id": "ef6b962a-67c8-4dc5-8190-b441a364da2c",
       "cluster_name": "",
       "last_checked_at": "2021-07-20T07:02:39.709Z",
       "total_hit_count": 21,
-      "hits_by_total_risk": { "1": 2, "2": 13, "3": 5, "4": 1 }
+      "hits_by_total_risk": {
+        "1": 2,
+        "2": 13,
+        "3": 5,
+        "4": 1
+      },
+      "cluster_version": ""
     },
     {
       "cluster_id": "7795cbcd-0353-4e59-b920-fc1c39a27064",
       "cluster_name": "ss8gckqoc lbukzf7pwi",
       "last_checked_at": "2021-11-26T12:39:41.512Z",
       "total_hit_count": 0,
-      "hits_by_total_risk": { "1": 0, "2": 0, "3": 0, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0
+      },
+      "cluster_version": "4.18.12"
     },
     {
       "cluster_id": "e6b7e3c9-59a2-4666-8f31-a3d8aad9ed32",
       "cluster_name": "7vymuht3 uba0sq6jyi",
       "last_checked_at": "2020-09-29T12:27:48.188Z",
       "total_hit_count": 27,
-      "hits_by_total_risk": { "1": 2, "2": 19, "3": 6, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 2,
+        "2": 19,
+        "3": 6,
+        "4": 0
+      },
+      "cluster_version": "4.6.9"
     },
     {
       "cluster_id": "99d8d133-e5fc-42f2-981d-d88932023e48",
       "cluster_name": "qjydd73t8 q0kx4ca95l",
       "total_hit_count": 0,
-      "hits_by_total_risk": { "1": 0, "2": 0, "3": 0, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0
+      },
+      "cluster_version": "4.1.2"
     },
     {
       "cluster_id": "a2f15021-ba2a-46a4-af1d-8966b681249d",
       "cluster_name": "",
       "last_checked_at": "2019-07-21T18:37:25.346Z",
       "total_hit_count": 23,
-      "hits_by_total_risk": { "1": 6, "2": 9, "3": 7, "4": 1 }
+      "hits_by_total_risk": {
+        "1": 6,
+        "2": 9,
+        "3": 7,
+        "4": 1
+      },
+      "cluster_version": "4.7.10"
     },
     {
       "cluster_id": "d35f7b4d-40fa-4ccd-b43c-e81137deaebd",
       "cluster_name": "",
       "last_checked_at": "2021-04-09T17:55:29.729Z",
       "total_hit_count": 29,
-      "hits_by_total_risk": { "1": 7, "2": 18, "3": 0, "4": 4 }
+      "hits_by_total_risk": {
+        "1": 7,
+        "2": 18,
+        "3": 0,
+        "4": 4
+      },
+      "cluster_version": "4.18.12"
     },
     {
       "cluster_id": "084ac7a7-1c7d-49ff-b56e-f94881da242d",
       "cluster_name": "gen1t0mfs ia532w7tz",
       "last_checked_at": "2019-04-16T10:16:22.865Z",
       "total_hit_count": 25,
-      "hits_by_total_risk": { "1": 1, "2": 19, "3": 2, "4": 3 }
+      "hits_by_total_risk": {
+        "1": 1,
+        "2": 19,
+        "3": 2,
+        "4": 3
+      },
+      "cluster_version": "3.0.3"
     },
     {
       "cluster_id": "de4cfd37-4c8e-4cb6-abba-cbf488d22390",
       "cluster_name": "1ghhxwjfoi 5b5hbyv07",
       "last_checked_at": "2021-08-02T11:14:13.329Z",
       "total_hit_count": 17,
-      "hits_by_total_risk": { "1": 5, "2": 3, "3": 8, "4": 1 }
+      "hits_by_total_risk": {
+        "1": 5,
+        "2": 3,
+        "3": 8,
+        "4": 1
+      },
+      "cluster_version": "4.8.27"
     },
     {
       "cluster_id": "956cc95d-9f65-4a6a-800c-f14f7ab6f812",
       "cluster_name": "t9ypvmelgg 9fbqdh0epk",
       "last_checked_at": "2020-07-17T04:01:59.093Z",
       "total_hit_count": 22,
-      "hits_by_total_risk": { "1": 2, "2": 8, "3": 8, "4": 4 }
+      "hits_by_total_risk": {
+        "1": 2,
+        "2": 8,
+        "3": 8,
+        "4": 4
+      },
+      "cluster_version": "4.0.2"
     },
     {
       "cluster_id": "96699c7a-9e72-4400-87b7-b314aebfe7fb",
       "cluster_name": "jpy8emdxh mkt86jqvj",
       "last_checked_at": "2020-04-21T16:58:15.823Z",
       "total_hit_count": 9,
-      "hits_by_total_risk": { "1": 3, "2": 0, "3": 5, "4": 1 }
+      "hits_by_total_risk": {
+        "1": 3,
+        "2": 0,
+        "3": 5,
+        "4": 1
+      },
+      "cluster_version": "4.4.24"
     },
     {
       "cluster_id": "849f9d51-f22a-444d-a601-d4512307b7da",
       "cluster_name": "s8yl8o7kr 5cb21ou71",
       "last_checked_at": "2019-07-19T08:18:12.495Z",
       "total_hit_count": 23,
-      "hits_by_total_risk": { "1": 5, "2": 13, "3": 2, "4": 3 }
+      "hits_by_total_risk": {
+        "1": 5,
+        "2": 13,
+        "3": 2,
+        "4": 3
+      },
+      "cluster_version": "4.17.9"
     },
     {
       "cluster_id": "fc603601-0ff8-45e4-b0f3-c7f76d2ef36b",
       "cluster_name": "gsbq8pthf xah3olxhz",
       "last_checked_at": "2019-02-09T13:43:12.855Z",
       "total_hit_count": 0,
-      "hits_by_total_risk": { "1": 0, "2": 0, "3": 0, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0
+      },
+      "cluster_version": "4.5.5"
     },
     {
       "cluster_id": "deba971e-8f8c-4e37-8e0a-4655523250de",
       "cluster_name": "",
       "last_checked_at": "2021-02-23T11:13:10.518Z",
       "total_hit_count": 20,
-      "hits_by_total_risk": { "1": 0, "2": 9, "3": 9, "4": 2 }
+      "hits_by_total_risk": {
+        "1": 0,
+        "2": 9,
+        "3": 9,
+        "4": 2
+      },
+      "cluster_version": "4.7.7"
     },
     {
       "cluster_id": "707e82e4-34f3-4ad8-8814-28cadd718e1a",
       "cluster_name": "",
       "last_checked_at": "2020-05-15T23:10:49.825Z",
       "total_hit_count": 41,
-      "hits_by_total_risk": { "1": 14, "2": 18, "3": 7, "4": 2 }
+      "hits_by_total_risk": {
+        "1": 14,
+        "2": 18,
+        "3": 7,
+        "4": 2
+      },
+      "cluster_version": "4.1.2"
     },
     {
       "cluster_id": "d5b3b06a-31af-4ebe-8192-2fde8a811a62",
       "cluster_name": "",
       "last_checked_at": "2021-02-21T05:12:59.441Z",
       "total_hit_count": 0,
-      "hits_by_total_risk": { "1": 0, "2": 0, "3": 0, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0
+      },
+      "cluster_version": ""
     },
     {
       "cluster_id": "cc59cabb-cb40-4a7e-8665-feb822a210e3",
       "cluster_name": "",
       "last_checked_at": "2019-12-18T14:21:12.020Z",
       "total_hit_count": 19,
-      "hits_by_total_risk": { "1": 11, "2": 8, "3": 0, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 11,
+        "2": 8,
+        "3": 0,
+        "4": 0
+      },
+      "cluster_version": "4.17.9"
     },
     {
       "cluster_id": "0abb45ac-3ade-49c7-a7d4-ec2af0ee21db",
       "cluster_name": "y7gz4faz1 k6rqb02yo",
       "total_hit_count": 0,
-      "hits_by_total_risk": { "1": 0, "2": 0, "3": 0, "4": 0 }
+      "hits_by_total_risk": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0
+      },
+      "cluster_version": "4.3.24"
     }
   ],
   "meta": {

--- a/cypress/utils/filters.js
+++ b/cypress/utils/filters.js
@@ -10,6 +10,12 @@ import { CHIP_GROUP, CHIP } from './components';
 
 const FILTERS_DROPDOWN = 'ul[class=pf-c-dropdown__menu]';
 const FILTER_TOGGLE = 'span[class=pf-c-select__toggle-arrow]';
+const VERSION_COMBINATIONS = [
+  ['4.18.12'],
+  ['4.17.9'],
+  ['3.0.3'],
+  ['4.18.12', '4.17.9'],
+];
 
 /**
  * A filter configuration
@@ -95,4 +101,4 @@ function filter(conf, data, filters) {
   return filteredData;
 }
 
-export { applyFilters, urlParamConvert, hasChip, filter };
+export { applyFilters, urlParamConvert, hasChip, filter, VERSION_COMBINATIONS };

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -221,11 +221,11 @@ export const CLUSTERS_LIST_COLUMNS = [
   },
   {
     title: intl.formatMessage(messages.version),
-    transforms: [sortable, cellWidth(10)],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.recommendations),
-    transforms: [sortable],
+    transforms: [sortable, cellWidth(15)],
   },
   {
     title: intl.formatMessage(messages.critical),

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -248,8 +248,6 @@ export const CLUSTERS_LIST_COLUMNS = [
     transforms: [sortable],
   },
 ];
-export const CLUSTER_NAME_CELL = 0;
-export const CLUSTER_LAST_CHECKED_CELL = 6;
 export const RECS_LIST_COLUMNS_KEYS = [
   '', // reserved for expand button
   'description',
@@ -323,6 +321,7 @@ export const LIKELIHOOD_LABEL_LOWER = {
 };
 export const CLUSTERS_LIST_COLUMNS_KEYS = [
   'name',
+  'version',
   'recommendations',
   'critical',
   'important',
@@ -330,3 +329,11 @@ export const CLUSTERS_LIST_COLUMNS_KEYS = [
   'low',
   'last_seen',
 ];
+export const CLUSTERS_TABLE_CELL_NAME = 0;
+export const CLUSTERS_TABLE_CELL_VERSION = 1;
+export const CLUSTERS_TABLE_CELL_RECOMMENDATIONS = 2;
+export const CLUSTERS_TABLE_CELL_CRITICAL = 3;
+export const CLUSTERS_TABLE_CELL_IMPORTANT = 4;
+export const CLUSTERS_TABLE_CELL_MODERATE = 5;
+export const CLUSTERS_TABLE_CELL_LOW = 6;
+export const CLUSTERS_TABLE_CELL_LAST_SEEN = 7;

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -220,28 +220,32 @@ export const CLUSTERS_LIST_COLUMNS = [
     transforms: [sortable, cellWidth(30)],
   },
   {
+    title: intl.formatMessage(messages.version),
+    transforms: [sortable, cellWidth(10)],
+  },
+  {
     title: intl.formatMessage(messages.recommendations),
-    transforms: [sortable, cellWidth(15)],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.critical),
-    transforms: [sortable, cellWidth(10)],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.important),
-    transforms: [sortable, cellWidth(10)],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.moderate),
-    transforms: [sortable, cellWidth(10)],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.low),
-    transforms: [sortable, cellWidth(10)],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.lastSeen),
-    transforms: [sortable, cellWidth(15)],
+    transforms: [sortable],
   },
 ];
 export const CLUSTER_NAME_CELL = 0;

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -202,7 +202,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
           </span>,
           <span key={r.id}>
             {r.cells[AFFECTED_CLUSTERS_VERSION_CELL] ||
-              intl.formatMessage(messages.nA)}
+              intl.formatMessage(messages.notAvailable)}
           </span>,
           <span key={r.id}>
             {r.cells[AFFECTED_CLUSTERS_LAST_SEEN_CELL] ? (

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -42,17 +42,12 @@ import {
 } from '../../../cypress/utils/pagination';
 import rule from '../../../cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY.json';
 import { AFFECTED_CLUSTERS_COLUMNS } from '../../AppConstants';
+import { VERSION_COMBINATIONS } from '../../../cypress/utils/filters';
 
 // selectors
 const ROOT = 'div[id=affected-list-table]';
 const BULK_SELECT = 'clusters-selector';
 const SEARCH_ITEMS = ['ff', 'CUSTOM', 'Foobar', 'Not existing cluster'];
-const VERSION_COMBINATIONS = [
-  ['4.18.12'],
-  ['4.17.9'],
-  ['3.0.3'],
-  ['4.18.12', '4.17.9'],
-];
 const TABLE_HEADERS = _.map(AFFECTED_CLUSTERS_COLUMNS, (it) => it.title);
 
 let data = _.cloneDeep(clusterDetailData.data['enabled']);

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -4,6 +4,9 @@ import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { useLocation } from 'react-router-dom';
+import uniqBy from 'lodash/uniqBy';
+import { valid } from 'semver';
+import { Link } from 'react-router-dom';
 
 import {
   SortByDirection,
@@ -19,7 +22,10 @@ import {
   Pagination,
   PaginationVariant,
 } from '@patternfly/react-core/dist/js/components/Pagination';
+import { Tooltip } from '@patternfly/react-core';
 import PrimaryToolbar from '@redhat-cloud-services/frontend-components/PrimaryToolbar/PrimaryToolbar';
+import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter/conditionalFilterConstants';
 
 import {
   CLUSTERS_LIST_INITIAL_STATE,
@@ -28,13 +34,13 @@ import {
 import {
   CLUSTERS_LIST_COLUMNS,
   CLUSTERS_LIST_COLUMNS_KEYS,
+  CLUSTERS_TABLE_CELL_NAME,
+  CLUSTERS_TABLE_CELL_LAST_SEEN,
+  CLUSTERS_TABLE_CELL_VERSION,
   CLUSTER_FILTER_CATEGORIES,
-  CLUSTER_LAST_CHECKED_CELL,
-  CLUSTER_NAME_CELL,
 } from '../../AppConstants';
 import {
   buildFilterChips,
-  mapClustersToRows,
   paramParser,
   passFiltersCluster,
   removeFilterParam as _removeFilterParam,
@@ -50,8 +56,6 @@ import {
   NoMatchingClusters,
   NoRecsForClusters,
 } from '../MessageState/EmptyStates';
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter/conditionalFilterConstants';
-import uniqBy from 'lodash/uniqBy';
 
 const ClustersListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
@@ -82,19 +86,11 @@ const ClustersListTable = ({
     _addFilterParam(filters, updateFilters, param, values);
 
   useEffect(() => {
-    setDisplayedRows(
-      buildDisplayedRows(filteredRows, filters.sortIndex, filters.sortDirection)
-    );
-  }, [
-    filteredRows,
-    filters.sortIndex,
-    filters.sortDirection,
-    filters.limit,
-    filters.offset,
-  ]);
+    setDisplayedRows(buildDisplayedRows(filteredRows));
+  }, [filteredRows, filters.limit, filters.offset]);
 
   useEffect(() => {
-    setFilteredRows(buildFilteredRows(clusters, filters));
+    setFilteredRows(buildFilteredRows(clusters));
     if (isSuccess && !rowsFiltered) {
       setRowsFiltered(true);
     }
@@ -129,37 +125,90 @@ const ClustersListTable = ({
     }
   }, [filters, filterBuilding]);
 
-  const buildFilteredRows = (allRows, filters) =>
-    mapClustersToRows(
-      allRows.filter((cluster) => passFiltersCluster(cluster, filters))
-    );
+  const buildFilteredRows = (items) => {
+    const filtered = items.filter((it) => {
+      return passFiltersCluster(it, filters);
+    });
+    const mapped = filtered.map((it, index) => {
+      if (it.cluster_version !== '' && !valid(it.cluster_version)) {
+        console.error(
+          `Cluster version ${it.cluster_version} has invalid format!`
+        );
+      }
 
-  const buildDisplayedRows = (rows, index, direction) => {
-    const sorted = [...rows];
-    index !== -1 &&
-      sorted.sort((a, b) => {
-        let fst, snd;
-        const d = direction === SortByDirection.asc ? 1 : -1;
-        switch (index) {
-          case CLUSTER_NAME_CELL:
-            fst = a.cluster.cluster_name || a.cluster.cluster_id;
-            snd = b.cluster.cluster_name || b.cluster.cluster_id;
-            return fst.localeCompare(snd) ? fst.localeCompare(snd) * d : 0;
-          case CLUSTER_LAST_CHECKED_CELL:
-            fst = new Date(a.cluster.last_checked_at || 0);
-            snd = new Date(b.cluster.last_checked_at || 0);
-            return fst > snd ? d : snd > fst ? -d : 0;
-          default:
-            fst = a.cells[index];
-            snd = b.cells[index];
-            return fst > snd ? d : snd > fst ? -d : 0;
-        }
-      });
-    return sorted.slice(
+      return {
+        entity: it,
+        cells: [
+          <span key={index}>
+            <Link to={`clusters/${it.cluster_id}`}>
+              {it.cluster_name || it.cluster_id}
+            </Link>
+          </span>,
+          it.cluster_version || intl.formatMessage(messages.notAvailable),
+          it.total_hit_count,
+          it.hits_by_total_risk?.[4] || 0,
+          it.hits_by_total_risk?.[3] || 0,
+          it.hits_by_total_risk?.[2] || 0,
+          it.hits_by_total_risk?.[1] || 0,
+          <span key={index}>
+            {it.last_checked_at ? (
+              <DateFormat
+                extraTitle={`${intl.formatMessage(messages.lastSeen)}: `}
+                date={it.last_checked_at}
+                variant="relative"
+              />
+            ) : (
+              <Tooltip
+                key={index}
+                content={
+                  <span>
+                    {intl.formatMessage(messages.lastSeen) + ': '}
+                    {intl.formatMessage(messages.nA)}
+                  </span>
+                }
+              >
+                <span>{intl.formatMessage(messages.nA)}</span>
+              </Tooltip>
+            )}
+          </span>,
+        ],
+      };
+    });
+    const sorted =
+      filters.sortIndex === -1
+        ? mapped
+        : mapped.sort((a, b) => {
+            let fst, snd;
+            const d = filters.sortDirection === SortByDirection.asc ? 1 : -1;
+            switch (filters.sortIndex) {
+              case CLUSTERS_TABLE_CELL_NAME:
+                fst = a.entity.cluster_name || a.entity.cluster_id;
+                snd = b.entity.cluster_name || b.entity.cluster_id;
+                return fst.localeCompare(snd) ? fst.localeCompare(snd) * d : 0;
+              case CLUSTERS_TABLE_CELL_VERSION:
+                return compareSemVer(
+                  a.entity.cluster_version || '0.0.0',
+                  b.entity.cluster_version || '0.0.0',
+                  d
+                );
+              case CLUSTERS_TABLE_CELL_LAST_SEEN:
+                fst = new Date(a.entity.last_checked_at || 0);
+                snd = new Date(b.entity.last_checked_at || 0);
+                return fst > snd ? d : snd > fst ? -d : 0;
+              default:
+                fst = a.cells[filters.sortIndex];
+                snd = b.cells[filters.sortIndex];
+                return fst > snd ? d : snd > fst ? -d : 0;
+            }
+          });
+    return sorted;
+  };
+
+  const buildDisplayedRows = (items) =>
+    items.slice(
       filters.limit * (page - 1),
       filters.limit * (page - 1) + filters.limit
     );
-  };
 
   const filterConfigItems = [
     {

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -41,6 +41,7 @@ import {
   addFilterParam as _addFilterParam,
   translateSortParams,
   updateSearchParams,
+  compareSemVer,
 } from '../Common/Tables';
 import Loading from '../Loading/Loading';
 import messages from '../../Messages';
@@ -49,6 +50,8 @@ import {
   NoMatchingClusters,
   NoRecsForClusters,
 } from '../MessageState/EmptyStates';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter/conditionalFilterConstants';
+import uniqBy from 'lodash/uniqBy';
 
 const ClustersListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
@@ -95,7 +98,7 @@ const ClustersListTable = ({
     if (isSuccess && !rowsFiltered) {
       setRowsFiltered(true);
     }
-  }, [data, filters.hits, filters.text]);
+  }, [data, filters]);
 
   useEffect(() => {
     if (search && filterBuilding) {
@@ -166,6 +169,27 @@ const ClustersListTable = ({
         onChange: (_event, value) => updateFilters({ ...filters, text: value }),
         value: filters.text,
         placeholder: intl.formatMessage(messages.filterByName),
+      },
+    },
+    {
+      label: intl.formatMessage(messages.version),
+      placeholder: intl.formatMessage(messages.filterByVersion),
+      type: conditionalFilterType.checkbox,
+      filterValues: {
+        id: 'version-filter',
+        key: 'version-filter',
+        onChange: (event, value) => addFilterParam('version', value),
+        value: filters.version,
+        items: uniqBy(
+          clusters
+            .filter((c) => c.cluster_version !== '')
+            .map((c) => ({
+              value: c.cluster_version,
+            }))
+            .sort((a, b) => compareSemVer(a.value, b.value, 1))
+            .reverse(), // should start from the latest version
+          'value'
+        ),
       },
     },
     {

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -77,18 +77,6 @@ const TOTAL_RISK_MAP = _.cloneDeep(TOTAL_RISK);
 TOTAL_RISK_MAP['All clusters'] = 'all';
 
 const filtersConf = {
-  version: {
-    selectorText: 'Version',
-    values: Array.from(
-      cumulativeCombinations(_.uniq(_.flatten(VERSION_COMBINATIONS)))
-    ),
-    type: 'checkbox',
-    filterFunc: (it, value) => {
-      return value.includes(it.cluster_version);
-    },
-    urlParam: 'version',
-    urlValue: (it) => encodeURIComponent(String(it)),
-  },
   name: {
     selectorText: 'Name',
     values: ['Foo', 'Foo Bar', 'Not existing cluster'],
@@ -111,6 +99,18 @@ const filtersConf = {
     urlParam: 'hits',
     urlValue: (it) =>
       encodeURIComponent(_.map(it, (x) => TOTAL_RISK_MAP[x]).join(',')),
+  },
+  version: {
+    selectorText: 'Version',
+    values: Array.from(
+      cumulativeCombinations(_.uniq(_.flatten(VERSION_COMBINATIONS)))
+    ),
+    type: 'checkbox',
+    filterFunc: (it, value) => {
+      return value.includes(it.cluster_version);
+    },
+    urlParam: 'version',
+    urlValue: (it) => encodeURIComponent(String(it)),
   },
 };
 
@@ -376,7 +376,6 @@ describe('clusters list table', () => {
             category = (it) => it.last_checked_at || '1970-01-01T01:00:00.001Z';
           }
 
-          cy.log(data, clusters);
           // add property name to clusters
           let sortedNames = _.map(
             // all tables must preserve original ordering
@@ -435,7 +434,7 @@ describe('clusters list table', () => {
       // TODO headers are displayed
     });
 
-    describe.only('single filter', () => {
+    describe('single filter', () => {
       Object.entries(filtersConf).forEach(([k, v]) => {
         v.values.forEach((filterValues) => {
           it(`${k}: ${filterValues}`, () => {

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -319,7 +319,7 @@ describe('clusters list table', () => {
     });
   });
 
-  describe.only('filtering', () => {
+  describe('filtering', () => {
     // TODO improve filtering tests
     // TODO check that empty table is displayed with appropriate filters
 

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -116,9 +116,18 @@ const filtersConf = {
 
 const DEFAULT_FILTERS = { risk: ['All clusters'] };
 
-// TODO invert parameters and make data optional as well0
-const filterData = (data, filters = DEFAULT_FILTERS) =>
-  filter(filtersConf, data, filters);
+// TODO invert parameters and make data optional as well
+const filterData = (data, filters = DEFAULT_FILTERS) => {
+  if (!_.has(filters, 'risk')) {
+    // absence of "risk" means there are only clusters that have at least 1 hit
+    return filter(
+      filtersConf,
+      _.filter(data, (it) => it.total_hit_count > 0),
+      filters
+    );
+  }
+  return filter(filtersConf, data, filters);
+};
 const filterApply = (filters) => applyFilters(filters, filtersConf);
 
 // TODO add more combinations of filters for testing

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -1,19 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import capitalize from 'lodash/capitalize';
 import cloneDeep from 'lodash/cloneDeep';
+import { useEffect, useState } from 'react';
 import { compare } from 'semver';
-
-import { Tooltip } from '@patternfly/react-core/dist/js/components/Tooltip';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
-
 import {
   CLUSTER_FILTER_CATEGORIES,
   FILTER_CATEGORIES,
-  intl,
   RULE_CATEGORIES,
 } from '../../AppConstants';
-import messages from '../../Messages';
 
 export const passFilters = (rule, filters) =>
   Object.entries(filters).every(([filterKey, filterValue]) => {

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -70,6 +70,11 @@ export const passFiltersCluster = (cluster, filters) =>
           // clusters with at least one rule hit for any of the active risk filters
           filterValue.some((v) => cluster.hits_by_total_risk[v] > 0)
         );
+      case 'version':
+        return (
+          filterValue.length === 0 ||
+          filterValue.includes(cluster.cluster_version)
+        );
       default:
         return true;
     }
@@ -84,6 +89,7 @@ export const mapClustersToRows = (clusters) =>
           {cluster.cluster_name || cluster.cluster_id}
         </Link>
       </span>,
+      cluster.cluster_version || intl.formatMessage(messages.notAvailable),
       cluster.total_hit_count,
       cluster.hits_by_total_risk?.[4] || 0,
       cluster.hits_by_total_risk?.[3] || 0,

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -80,45 +80,6 @@ export const passFiltersCluster = (cluster, filters) =>
     }
   });
 
-export const mapClustersToRows = (clusters) =>
-  clusters.map((cluster, index) => ({
-    cluster,
-    cells: [
-      <span key={index}>
-        <Link to={`clusters/${cluster.cluster_id}`}>
-          {cluster.cluster_name || cluster.cluster_id}
-        </Link>
-      </span>,
-      cluster.cluster_version || intl.formatMessage(messages.notAvailable),
-      cluster.total_hit_count,
-      cluster.hits_by_total_risk?.[4] || 0,
-      cluster.hits_by_total_risk?.[3] || 0,
-      cluster.hits_by_total_risk?.[2] || 0,
-      cluster.hits_by_total_risk?.[1] || 0,
-      <span key={index}>
-        {cluster.last_checked_at ? (
-          <DateFormat
-            extraTitle={`${intl.formatMessage(messages.lastSeen)}: `}
-            date={cluster.last_checked_at}
-            variant="relative"
-          />
-        ) : (
-          <Tooltip
-            key={index}
-            content={
-              <span>
-                {intl.formatMessage(messages.lastSeen) + ': '}
-                {intl.formatMessage(messages.nA)}
-              </span>
-            }
-          >
-            <span>{intl.formatMessage(messages.nA)}</span>
-          </Tooltip>
-        )}
-      </span>,
-    ],
-  }));
-
 const pruneFilters = (localFilters, filterCategories) => {
   const prunedFilters = Object.entries(localFilters || {});
   return prunedFilters.reduce((arr, it) => {

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -1,7 +1,7 @@
 import capitalize from 'lodash/capitalize';
 import cloneDeep from 'lodash/cloneDeep';
 import { useEffect, useState } from 'react';
-import { compare } from 'semver';
+import { coerce, compare, valid } from 'semver';
 import {
   CLUSTER_FILTER_CATEGORIES,
   FILTER_CATEGORIES,
@@ -66,7 +66,7 @@ export const passFiltersCluster = (cluster, filters) =>
       case 'version':
         return (
           filterValue.length === 0 ||
-          filterValue.includes(cluster.cluster_version)
+          filterValue.includes(toValidSemVer(cluster.cluster_version))
         );
       default:
         return true;
@@ -221,6 +221,9 @@ export const updateSearchParams = (filters = {}, columnMapping) => {
 
 // TODO: move to Utils.js
 export const compareSemVer = (v1, v2, d) => d * compare(v1, v2);
+export const toValidSemVer = (version) =>
+  coerce(version === undefined || !valid(coerce(version)) ? '0.0.0' : version)
+    .version;
 
 export const removeFilterParam = (currentFilters, updateFilters, param) => {
   const { [param]: omitted, ...newFilters } = { ...currentFilters, offset: 0 };

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -605,4 +605,8 @@ export default defineMessages({
     id: 'filterByVersion',
     defaultMessage: 'Filter by version',
   },
+  notAvailable: {
+    id: 'notAvailable',
+    defaultMessage: 'Not available',
+  },
 });

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -29,6 +29,7 @@ export const CLUSTERS_LIST_INITIAL_STATE = {
   sortIndex: 6,
   sortDirection: 'desc',
   text: '',
+  version: [],
 };
 
 // single cluster page

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -1,10 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { CLUSTERS_TABLE_CELL_LAST_SEEN } from '../AppConstants';
 
 // single recommendation page
 export const AFFECTED_CLUSTERS_INITIAL_STATE = {
   limit: 20,
   offset: 0,
   text: '',
+  // TODO: use a constant instead
   sortIndex: 3,
   sortDirection: null,
   version: [],
@@ -16,6 +18,7 @@ export const RECS_LIST_INITIAL_STATE = {
   offset: 0,
   impacting: ['true'],
   // default sorting by total risk
+  // TODO: use a constant instead
   sortIndex: 4,
   sortDirection: 'desc',
   rule_status: 'enabled',
@@ -26,7 +29,7 @@ export const CLUSTERS_LIST_INITIAL_STATE = {
   limit: 20,
   offset: 0,
   hits: ['all'],
-  sortIndex: 6,
+  sortIndex: CLUSTERS_TABLE_CELL_LAST_SEEN,
   sortDirection: 'desc',
   text: '',
   version: [],
@@ -37,6 +40,7 @@ export const CLUSTER_RULES_INITIAL_STATE = {
   limit: 20,
   offset: 0,
   // default sorting by total risk
+  // TODO: use a constant instead
   sortIndex: -1,
   sortDirection: 'desc',
   text: '',


### PR DESCRIPTION
The PR makes the clusters list view render the cluster version column. The value is contained in the API response (`GET /v2/clusters`) within the `cluster_version` path.

Mocked in https://marvelapp.com/prototype/g70a1he/screen/82818324.
Implements https://issues.redhat.com/browse/CCXDEV-7011.

![Screenshot 2022-05-19 at 16-07-58 Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/169313816-98854977-1655-40c7-8e0b-a9864b0efc8d.png)
![Screenshot 2022-05-19 at 16-07-43 Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/169313821-ecafcf10-1198-41f7-bd12-9dfa57825899.png)
![Screenshot 2022-05-19 at 16-07-27 Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/169313826-6e93eef5-5560-47bc-b903-0e562ddb61fa.png)

- [x] Display cluster version
- [x] Implement filtering
- [x] Implement sorting
- [x] Add tests
- [x] Rename N/A to Not available in the Affected clusters table