### PR TITLE
Request GET cluster/{id}/info to obtain cluster display name

### DIFF
--- a/src/Components/ClusterHeader/ClusterHeader.js
+++ b/src/Components/ClusterHeader/ClusterHeader.js
@@ -16,7 +16,7 @@ import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat/Da
 import messages from '../../Messages';
 import { OneLineLoader } from '../../Utilities/Loaders';
 
-export const ClusterHeader = ({ clusterId, clusterData }) => {
+export const ClusterHeader = ({ clusterId, clusterData, clusterInfo }) => {
   const location = window.location;
   const [isOpen, setIsOpen] = useState(false);
   const intl = useIntl();
@@ -26,6 +26,12 @@ export const ClusterHeader = ({ clusterId, clusterData }) => {
     isFetching: isFetchingCluster,
     data: cluster,
   } = clusterData;
+
+  const {
+    isUninitialized: isUninitializedInfo,
+    isFetching: isFetchingInfo,
+    data: info,
+  } = clusterInfo;
 
   const redirectOCM = (clusterId) => {
     location.assign(
@@ -44,18 +50,18 @@ export const ClusterHeader = ({ clusterId, clusterData }) => {
   return (
     <Grid id="cluster-header" md={12} hasGutter>
       <GridItem span={8}>
-        {isUninitializedCluster || isFetchingCluster ? (
-          <Skeleton size="sm" />
-        ) : (
-          <Title
-            size="2xl"
-            headingLevel="h1"
-            id="cluster-header-title"
-            ouiaId="cluster-name"
-          >
-            {clusterData?.data?.report?.meta.cluster_name || clusterId}
-          </Title>
-        )}
+        <Title
+          size="2xl"
+          headingLevel="h1"
+          id="cluster-header-title"
+          ouiaId="cluster-name"
+        >
+          {isUninitializedInfo || isFetchingInfo ? (
+            <Skeleton size="sm" />
+          ) : (
+            info?.display_name || clusterId
+          )}
+        </Title>
       </GridItem>
       <GridItem span={4} id="cluster-header-dropdown">
         <Dropdown
@@ -77,8 +83,7 @@ export const ClusterHeader = ({ clusterId, clusterData }) => {
       <GridItem>
         <Stack>
           <StackItem id="cluster-header-uuid">
-            <span>UUID: </span>
-            <span>{clusterId || intl.formatMessage(messages.unknown)}</span>
+            <span>UUID:</span> <span>{clusterId}</span>
           </StackItem>
           <StackItem id="cluster-header-last-seen">
             <span>{intl.formatMessage(messages.lastSeen)}: </span>
@@ -103,6 +108,15 @@ export const ClusterHeader = ({ clusterId, clusterData }) => {
 
 ClusterHeader.propTypes = {
   clusterId: PropTypes.string.isRequired,
-  displayName: PropTypes.object.isRequired,
   clusterData: PropTypes.object.isRequired,
+  clusterInfo: PropTypes.shape({
+    isUninitialized: PropTypes.bool.isRequired,
+    isFetching: PropTypes.bool.isRequired,
+    data: PropTypes.shape({
+      cluster_id: PropTypes.string,
+      display_name: PropTypes.string,
+      managed: PropTypes.bool,
+      status: PropTypes.string,
+    }),
+  }),
 };

--- a/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
+++ b/src/Components/ClusterHeader/ClusterHeader.spec.ct.js
@@ -22,9 +22,15 @@ describe('cluster page header', () => {
           report: {
             meta: {
               last_checked_at: '2021-07-24T14:22:36.109Z',
-              cluster_name: 'Cluster with issues',
             },
           },
+        },
+      },
+      clusterInfo: {
+        isUninitialized: false,
+        isFetching: false,
+        data: {
+          display_name: 'Cluster with issues',
         },
       },
     };
@@ -45,10 +51,10 @@ describe('cluster page header', () => {
   it('show skeleton when in the loading state', () => {
     props = {
       ...props,
-      displayName: {
-        ...props.displayName,
+      clusterInfo: {
+        isUninitialized: false,
         isFetching: true,
-        data: undefined,
+        data: null,
       },
     };
     mount(
@@ -58,7 +64,7 @@ describe('cluster page header', () => {
     );
     // check title
     cy.get(HEADER_TITLE).should('have.length', 1);
-    cy.get('.ins-c-skeleton').should('have.length', 0);
+    cy.get('.ins-c-skeleton').should('have.length', 1);
     // check uuid text
     cy.get(UUID_FIELD).should('have.text', 'foobar');
     // check uuid text
@@ -66,7 +72,7 @@ describe('cluster page header', () => {
   });
   // this test is not checking UUID but name
   it('show UUID when display name is unavailable', () => {
-    props.clusterData.data.report.meta.cluster_name = undefined;
+    props.clusterInfo.data.display_name = undefined;
     mount(
       <Intl>
         <ClusterHeader {...props} />

--- a/src/Components/ClusterHeader/index.js
+++ b/src/Components/ClusterHeader/index.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { useRouteMatch } from 'react-router-dom';
 
-import { useGetClusterByIdQuery } from '../../Services/SmartProxy';
+import {
+  useGetClusterByIdQuery,
+  useGetClusterInfoQuery,
+} from '../../Services/SmartProxy';
 import { ClusterHeader } from './ClusterHeader';
 
 const ClusterHeaderWrapper = () => {
@@ -11,8 +14,17 @@ const ClusterHeaderWrapper = () => {
     id: clusterId,
     includeDisabled: false,
   });
+  const clusterInfo = useGetClusterInfoQuery({
+    id: clusterId,
+  });
 
-  return <ClusterHeader clusterId={clusterId} clusterData={clusterData} />;
+  return (
+    <ClusterHeader
+      clusterId={clusterId}
+      clusterData={clusterData}
+      clusterInfo={clusterInfo}
+    />
+  );
 };
 
 export default ClusterHeaderWrapper;

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -33,6 +33,10 @@ export const SmartProxyApi = createApi({
         };
       },
     }),
+    getClusterInfo: builder.query({
+      query: ({ id }) => `v2/cluster/${id}/info`,
+      transformResponse: (response) => response?.cluster,
+    }),
   }),
 });
 
@@ -45,4 +49,5 @@ export const {
   useGetRecsQuery,
   useLazyGetRecsQuery,
   useGetClustersQuery,
+  useGetClusterInfoQuery,
 } = SmartProxyApi;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-7302.

Makes the Cluster Details page request an additional GET /cluster/{id}/info endpoint that provides a display name for the given cluster. Even when the GET /cluster/{id}/reports fails because of no Insights rules, the page must be still able to render the display name (if available).

![Screenshot from 2022-06-02 13-11-44](https://user-images.githubusercontent.com/31385370/171617300-542cf8c1-b582-4149-9a9c-7ce6e0542f22.png)
