### PR TITLE
Refactor empty state handling across tables; implement tests

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -60,7 +60,7 @@
   "noMatchingRecommendationsTitle": "No matching recommendations found",
   "noRecommendations": "The cluster is not affected by any known recommendations",
   "noRecommendationsDesc": "No known recommendations affect this cluster.",
-  "noRecsError": "No recommendations available.",
+  "noRecsError": "No recommendations available",
   "noRecsErrorDesc": "There was an error fetching recommendations for this cluster. Refresh your page to try again.",
   "noRecsForClusterListBody": "To get started, create or register your cluster to get recommendations from Insights Advisor.",
   "noRecsForClusterListTitle": "No clusters yet",

--- a/cypress/utils/components.js
+++ b/cypress/utils/components.js
@@ -15,6 +15,7 @@ const DROPDOWN_ITEM = '[data-ouia-component-type="PF4/DropdownItem"]';
 const TBODY = 'tbody[role=rowgroup]';
 const TOOLBAR_FILTER = '.ins-c-primary-toolbar__filter';
 const TABLE = 'table';
+const TITLE = '[data-ouia-component-type="PF4/Title"]';
 
 const ouiaId = (id) => `[data-ouia-component-id="${id}"]`;
 
@@ -35,4 +36,5 @@ export {
   TBODY,
   TOOLBAR_FILTER,
   TABLE,
+  TITLE,
 };

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -33,7 +33,7 @@ function tableIsSortedBy(columnTitle) {
     .should('have.class', 'pf-c-table__sort pf-m-selected');
 }
 
-function checkEmptyState(title, body, checkIcon = false) {
+function checkEmptyState(title, checkIcon = false) {
   cy.get(TABLE)
     .find('[ouiaid=empty-state]')
     .should('have.length', 1)
@@ -43,7 +43,6 @@ function checkEmptyState(title, body, checkIcon = false) {
         checkIcon ? 1 : 0
       );
       cy.get(`h5${TITLE}`).should('have.text', title);
-      cy.get('.pf-c-empty-state__body').should('have.text', body);
     });
 }
 

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -18,8 +18,10 @@ function checkTableHeaders(expectedHeaders) {
 
 // TODO fucntion to get rowgroup
 
-function checkRowCounts(n) {
-  return cy.get('table').find(TBODY).find(ROW).should('have.length', n);
+function checkRowCounts(n, isSelectableTable = false) {
+  return isSelectableTable
+    ? cy.get('table').find(TBODY).should('have.length', n)
+    : cy.get('table').find(TBODY).find(ROW).should('have.length', n);
 }
 
 function columnName2UrlParam(name) {

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -46,10 +46,20 @@ function checkEmptyState(title, checkIcon = false) {
     });
 }
 
+function checkNoMatchingClusters() {
+  return checkEmptyState('No matching clusters found');
+}
+
+function checkNoMatchingRecs() {
+  return checkEmptyState('No matching recommendations found');
+}
+
 export {
   checkTableHeaders,
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
   checkEmptyState,
+  checkNoMatchingClusters,
+  checkNoMatchingRecs,
 };

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { ROW, TBODY } from './components';
+import { ROW, TABLE, TBODY, TITLE } from './components';
 
 function checkTableHeaders(expectedHeaders) {
   /* patternfly/react-table-4.71.16, for some reason, renders extra empty `th` container;
@@ -33,9 +33,27 @@ function tableIsSortedBy(columnTitle) {
     .should('have.class', 'pf-c-table__sort pf-m-selected');
 }
 
+function checkNoMatchState(isRecsList) {
+  cy.get(TABLE)
+    .find('[ouiaid=empty-state]')
+    .should('have.length', 1)
+    .within(() => {
+      cy.get('.pf-c-empty-state__icon').should('have.length', 0);
+      cy.get(`h5${TITLE}`).should(
+        'have.text',
+        `No matching ${isRecsList ? 'recommendations' : 'clusters'} found`
+      );
+      cy.get('.pf-c-empty-state__body').should(
+        'have.text',
+        'To continue, edit your filter settings and search again.'
+      );
+    });
+}
+
 export {
   checkTableHeaders,
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
+  checkNoMatchState,
 };

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -36,6 +36,7 @@ function tableIsSortedBy(columnTitle) {
 }
 
 function checkEmptyState(title, checkIcon = false) {
+  checkRowCounts(1);
   cy.get(TABLE)
     .find('[ouiaid=empty-state]')
     .should('have.length', 1)

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -33,20 +33,17 @@ function tableIsSortedBy(columnTitle) {
     .should('have.class', 'pf-c-table__sort pf-m-selected');
 }
 
-function checkNoMatchState(isRecsList) {
+function checkEmptyState(title, body, checkIcon = false) {
   cy.get(TABLE)
     .find('[ouiaid=empty-state]')
     .should('have.length', 1)
     .within(() => {
-      cy.get('.pf-c-empty-state__icon').should('have.length', 0);
-      cy.get(`h5${TITLE}`).should(
-        'have.text',
-        `No matching ${isRecsList ? 'recommendations' : 'clusters'} found`
+      cy.get('.pf-c-empty-state__icon').should(
+        'have.length',
+        checkIcon ? 1 : 0
       );
-      cy.get('.pf-c-empty-state__body').should(
-        'have.text',
-        'To continue, edit your filter settings and search again.'
-      );
+      cy.get(`h5${TITLE}`).should('have.text', title);
+      cy.get('.pf-c-empty-state__body').should('have.text', body);
     });
 }
 
@@ -55,5 +52,5 @@ export {
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
-  checkNoMatchState,
+  checkEmptyState,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,6 +5116,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -5131,7 +5133,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -31696,15 +31700,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -31716,7 +31719,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -113,6 +113,8 @@ describe('test data', () => {
   });
 });
 
+// TODO: when checking empty state, also check toolbar available and not disabled
+
 describe('non-empty successful affected clusters table', () => {
   beforeEach(() => {
     mount(

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -30,7 +30,7 @@ import {
   checkTableHeaders,
   checkRowCounts,
   tableIsSortedBy,
-  checkNoMatchState,
+  checkEmptyState,
 } from '../../../cypress/utils/table';
 import {
   itemsPerPage,
@@ -478,7 +478,10 @@ describe('non-empty successful affected clusters table', () => {
             let sortedNames = _.map(filterData(filters), 'name');
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkNoMatchState();
+              checkEmptyState(
+                'No matching clusters found',
+                'To continue, edit your filter settings and search again.'
+              );
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -515,7 +518,10 @@ describe('non-empty successful affected clusters table', () => {
           let sortedNames = _.map(filterData(filters), 'name');
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkNoMatchState();
+            checkEmptyState(
+              'No matching clusters found',
+              'To continue, edit your filter settings and search again.'
+            );
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {
@@ -555,7 +561,10 @@ describe('non-empty successful affected clusters table', () => {
 
     it('empty state is displayed when filters do not match any rule', () => {
       cy.get('#name-filter').type('Not existing cluster');
-      checkNoMatchState();
+      checkEmptyState(
+        'No matching clusters found',
+        'To continue, edit your filter settings and search again.'
+      );
       checkTableHeaders(TABLE_HEADERS);
     });
   });

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -480,10 +480,7 @@ describe('non-empty successful affected clusters table', () => {
             let sortedNames = _.map(filterData(filters), 'name');
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkEmptyState(
-                'No matching clusters found',
-                'To continue, edit your filter settings and search again.'
-              );
+              checkEmptyState('No matching clusters found');
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -520,10 +517,7 @@ describe('non-empty successful affected clusters table', () => {
           let sortedNames = _.map(filterData(filters), 'name');
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkEmptyState(
-              'No matching clusters found',
-              'To continue, edit your filter settings and search again.'
-            );
+            checkEmptyState('No matching clusters found');
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {
@@ -563,10 +557,7 @@ describe('non-empty successful affected clusters table', () => {
 
     it('empty state is displayed when filters do not match any rule', () => {
       cy.get('#name-filter').type('Not existing cluster');
-      checkEmptyState(
-        'No matching clusters found',
-        'To continue, edit your filter settings and search again.'
-      );
+      checkEmptyState('No matching clusters found');
       checkTableHeaders(TABLE_HEADERS);
     });
   });
@@ -703,9 +694,7 @@ describe('empty successful affected clusters table', () => {
   });
 
   it('renders no clusters message', () => {
-    cy.get('[ouiaid="empty-state"]')
-      .find('h5')
-      .should('have.text', 'No clusters');
+    checkEmptyState('No clusters', true);
   });
 
   it('renders table headers', () => {

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -30,6 +30,7 @@ import {
   checkTableHeaders,
   checkRowCounts,
   tableIsSortedBy,
+  checkNoMatchState,
 } from '../../../cypress/utils/table';
 import {
   itemsPerPage,
@@ -477,8 +478,8 @@ describe('non-empty successful affected clusters table', () => {
             let sortedNames = _.map(filterData(filters), 'name');
             filterApply(filters);
             if (sortedNames.length === 0) {
-              // TODO check empty table view
-              // TODO headers are displayed
+              checkNoMatchState();
+              checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
                 .then(($els) => {
@@ -514,7 +515,7 @@ describe('non-empty successful affected clusters table', () => {
           let sortedNames = _.map(filterData(filters), 'name');
           filterApply(filters);
           if (sortedNames.length === 0) {
-            // TODO check empty table view
+            checkNoMatchState();
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {
@@ -554,8 +555,8 @@ describe('non-empty successful affected clusters table', () => {
 
     it('empty state is displayed when filters do not match any rule', () => {
       cy.get('#name-filter').type('Not existing cluster');
-      // TODO check empty table view
-      // TODO headers are displayed
+      checkNoMatchState();
+      checkTableHeaders(TABLE_HEADERS);
     });
   });
 
@@ -691,8 +692,8 @@ describe('empty successful affected clusters table', () => {
   });
 
   it('renders no clusters message', () => {
-    cy.get('#empty-state-message')
-      .find('h4')
+    cy.get('[ouiaid="empty-state"]')
+      .find('h5')
       .should('have.text', 'No clusters');
   });
 
@@ -728,8 +729,8 @@ describe('empty failed affected clusters table', () => {
   });
 
   it('renders error message', () => {
-    cy.get('#error-state-message')
-      .find('h4')
+    cy.get('[ouiaid="empty-state"]')
+      .find('h5')
       .should('have.text', 'Something went wrong');
   });
 

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -31,6 +31,7 @@ import {
   checkRowCounts,
   tableIsSortedBy,
   checkEmptyState,
+  checkNoMatchingClusters,
 } from '../../../cypress/utils/table';
 import {
   itemsPerPage,
@@ -480,7 +481,7 @@ describe('non-empty successful affected clusters table', () => {
             let sortedNames = _.map(filterData(filters), 'name');
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkEmptyState('No matching clusters found');
+              checkNoMatchingClusters();
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -517,7 +518,7 @@ describe('non-empty successful affected clusters table', () => {
           let sortedNames = _.map(filterData(filters), 'name');
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkEmptyState('No matching clusters found');
+            checkNoMatchingClusters;
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {
@@ -557,7 +558,7 @@ describe('non-empty successful affected clusters table', () => {
 
     it('empty state is displayed when filters do not match any rule', () => {
       cy.get('#name-filter').type('Not existing cluster');
-      checkEmptyState('No matching clusters found');
+      checkNoMatchingClusters();
       checkTableHeaders(TABLE_HEADERS);
     });
   });

--- a/src/Components/Cluster/Cluster.js
+++ b/src/Components/Cluster/Cluster.js
@@ -10,6 +10,7 @@ import Breadcrumbs from '../Breadcrumbs';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 
 export const Cluster = ({ cluster, match }) => {
+  // TODO: make breadcrumbs take display name from GET /cluster/id/info
   return (
     <React.Fragment>
       <PageHeader className="pf-m-light ins-inventory-detail">

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -7,7 +7,10 @@ import { Cluster } from './Cluster';
 import { Provider } from 'react-redux';
 import getStore from '../../Store';
 import singleClusterPageReport from '../../../cypress/fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/reports-disabled-false.json';
-import { checkEmptyState, checkRowCounts } from '../../../cypress/utils/table';
+import {
+  checkNoMatchingRecs,
+  checkRowCounts,
+} from '../../../cypress/utils/table';
 import { TBODY } from '../../../cypress/utils/components';
 
 // selectors
@@ -146,7 +149,7 @@ describe('cluster page', () => {
       expect($el.text()).to.be.oneOf(['foo bar', 'Low', 'Performance'])
     );
     checkRowCounts(1);
-    checkEmptyState('No matching recommendations found');
+    checkNoMatchingRecs();
   });
 
   it('adds additional filters passed by the query parameters №2', () => {
@@ -170,7 +173,7 @@ describe('cluster page', () => {
       ])
     );
     checkRowCounts(1);
-    checkEmptyState('No matching recommendations found');
+    checkNoMatchingRecs();
   });
 });
 

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -7,7 +7,8 @@ import { Cluster } from './Cluster';
 import { Provider } from 'react-redux';
 import getStore from '../../Store';
 import singleClusterPageReport from '../../../cypress/fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/reports-disabled-false.json';
-import { checkRowCounts } from '../../../cypress/utils/table';
+import { checkEmptyState, checkRowCounts } from '../../../cypress/utils/table';
+import { TBODY } from '../../../cypress/utils/components';
 
 // selectors
 const CLUSTER_HEADER = '#cluster-header';
@@ -62,7 +63,10 @@ describe('cluster page', () => {
     // renders table component
     cy.get(RULES_TABLE).should('have.length', 1);
     // test how many rows were rendered
-    checkRowCounts(singleClusterPageReport.report.data.length);
+    // TODO: for selectable rows, tbody is rendered for each row, and checkRowCounts doesn't work correctly
+    cy.get('table')
+      .find(TBODY)
+      .should('have.length', singleClusterPageReport.report.data.length);
   });
 
   it('cluster page in the loading state', () => {
@@ -90,7 +94,10 @@ describe('cluster page', () => {
     cy.get(CLUSTER_HEADER).should('have.length', 1);
     // renders table component
     cy.get(RULES_TABLE).should('have.length', 1);
-    cy.get('#loading-skeleton').should('have.length', 1);
+    cy.get('[data-ouia-component-id=loading-skeleton]').should(
+      'have.length',
+      1
+    );
   });
 
   it('cluster page in the error state', () => {
@@ -138,7 +145,11 @@ describe('cluster page', () => {
     cy.get(FILTER_CHIPS).each(($el) =>
       expect($el.text()).to.be.oneOf(['foo bar', 'Low', 'Performance'])
     );
-    checkRowCounts(0);
+    checkRowCounts(1);
+    checkEmptyState(
+      'No matching recommendations found',
+      'To continue, edit your filter settings and search again.'
+    );
   });
 
   it('adds additional filters passed by the query parameters №2', () => {
@@ -161,7 +172,11 @@ describe('cluster page', () => {
         'Service Availability',
       ])
     );
-    checkRowCounts(0);
+    checkRowCounts(1);
+    checkEmptyState(
+      'No matching recommendations found',
+      'To continue, edit your filter settings and search again.'
+    );
   });
 });
 
@@ -206,7 +221,9 @@ describe('Cluster page display name test №1', () => {
       <MemoryRouter>
         <Intl>
           <Provider store={getStore()}>
-            <Cluster cluster="" match={props.match} />
+            <Cluster
+              {...{ ...props, cluster: { ...props.cluster, data: null } }}
+            />
           </Provider>
         </Intl>
       </MemoryRouter>

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -146,10 +146,7 @@ describe('cluster page', () => {
       expect($el.text()).to.be.oneOf(['foo bar', 'Low', 'Performance'])
     );
     checkRowCounts(1);
-    checkEmptyState(
-      'No matching recommendations found',
-      'To continue, edit your filter settings and search again.'
-    );
+    checkEmptyState('No matching recommendations found');
   });
 
   it('adds additional filters passed by the query parameters №2', () => {
@@ -173,10 +170,7 @@ describe('cluster page', () => {
       ])
     );
     checkRowCounts(1);
-    checkEmptyState(
-      'No matching recommendations found',
-      'To continue, edit your filter settings and search again.'
-    );
+    checkEmptyState('No matching recommendations found');
   });
 });
 

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -11,7 +11,6 @@ import {
   checkNoMatchingRecs,
   checkRowCounts,
 } from '../../../cypress/utils/table';
-import { TBODY } from '../../../cypress/utils/components';
 
 // selectors
 const CLUSTER_HEADER = '#cluster-header';
@@ -94,10 +93,7 @@ describe('cluster page', () => {
     cy.get(CLUSTER_HEADER).should('have.length', 1);
     // renders table component
     cy.get(RULES_TABLE).should('have.length', 1);
-    cy.get('[data-ouia-component-id=loading-skeleton]').should(
-      'have.length',
-      1
-    );
+    cy.ouiaId('loading-skeleton').should('have.length', 1);
   });
 
   it('cluster page in the error state', () => {

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -141,7 +141,6 @@ describe('cluster page', () => {
     cy.get(FILTER_CHIPS).each(($el) =>
       expect($el.text()).to.be.oneOf(['foo bar', 'Low', 'Performance'])
     );
-    checkRowCounts(1);
     checkNoMatchingRecs();
   });
 
@@ -165,7 +164,6 @@ describe('cluster page', () => {
         'Service Availability',
       ])
     );
-    checkRowCounts(1);
     checkNoMatchingRecs();
   });
 });

--- a/src/Components/Cluster/Cluster.spec.ct.js
+++ b/src/Components/Cluster/Cluster.spec.ct.js
@@ -66,10 +66,7 @@ describe('cluster page', () => {
     // renders table component
     cy.get(RULES_TABLE).should('have.length', 1);
     // test how many rows were rendered
-    // TODO: for selectable rows, tbody is rendered for each row, and checkRowCounts doesn't work correctly
-    cy.get('table')
-      .find(TBODY)
-      .should('have.length', singleClusterPageReport.report.data.length);
+    checkRowCounts(singleClusterPageReport.report.data.length, true);
   });
 
   it('cluster page in the loading state', () => {

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -419,7 +419,7 @@ const ClusterRules = ({ cluster }) => {
       <Table
         aria-label={'Cluster recommendations table'}
         ouiaId="recommendations"
-        onCollapse={handleOnCollapse}
+        onCollapse={handleOnCollapse} // TODO: set undefined when there is an empty state
         rows={
           errorState || loadingState || noMatch || noInput ? (
             [

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -17,7 +17,10 @@ import {
 } from '../../../cypress/utils/globals';
 import { applyFilters, filter } from '../../../cypress/utils/filters';
 import { cumulativeCombinations } from '../../../cypress/utils/combine';
-import { checkTableHeaders } from '../../../cypress/utils/table';
+import {
+  checkEmptyState,
+  checkTableHeaders,
+} from '../../../cypress/utils/table';
 import {
   CHIP_GROUP,
   CHIP,
@@ -256,8 +259,11 @@ describe('cluster rules table', () => {
       filterApply({
         description: 'Not existing recommendation',
       });
-      // TODO check empty table view
-      // TODO headers are displayed
+      checkEmptyState(
+        'No matching recommendations found',
+        'To continue, edit your filter settings and search again.'
+      );
+      checkTableHeaders(TABLE_HEADERS);
     });
 
     describe('single filter', () => {
@@ -272,8 +278,11 @@ describe('cluster rules table', () => {
             ).sort();
             filterApply(filters);
             if (sortedDescriptions.length === 0) {
-              // TODO check empty table view
-              // TODO headers are displayed
+              checkEmptyState(
+                'No matching recommendations found',
+                'To continue, edit your filter settings and search again.'
+              );
+              checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Description"]`)
                 .then(($els) => {
@@ -315,7 +324,10 @@ describe('cluster rules table', () => {
           ).sort();
           filterApply(filters);
           if (sortedDescriptions.length === 0) {
-            // TODO check empty table view
+            checkEmptyState(
+              'No matching recommendations found',
+              'To continue, edit your filter settings and search again.'
+            );
           } else {
             cy.get(`td[data-label="Description"]`)
               .then(($els) => {
@@ -385,13 +397,11 @@ describe('empty cluster rules table', () => {
   });
 
   it('renders no recommendation message', () => {
-    cy.get('[data-ouia-component-id="no-recommendations"]')
-      .contains('The cluster is not affected by any known recommendations')
-      .should('exist');
-  });
-
-  it('does not render table', () => {
-    cy.get(TABLE).should('not.exist');
+    checkEmptyState(
+      'The cluster is not affected by any known recommendations',
+      'No known recommendations affect this cluster.',
+      true
+    );
   });
 });
 

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -19,6 +19,7 @@ import { applyFilters, filter } from '../../../cypress/utils/filters';
 import { cumulativeCombinations } from '../../../cypress/utils/combine';
 import {
   checkEmptyState,
+  checkNoMatchingRecs,
   checkTableHeaders,
 } from '../../../cypress/utils/table';
 import {
@@ -261,7 +262,7 @@ describe('cluster rules table', () => {
       filterApply({
         description: 'Not existing recommendation',
       });
-      checkEmptyState('No matching recommendations found');
+      checkNoMatchingRecs();
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -277,7 +278,7 @@ describe('cluster rules table', () => {
             ).sort();
             filterApply(filters);
             if (sortedDescriptions.length === 0) {
-              checkEmptyState('No matching recommendations found');
+              checkNoMatchingRecs();
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Description"]`)
@@ -320,7 +321,7 @@ describe('cluster rules table', () => {
           ).sort();
           filterApply(filters);
           if (sortedDescriptions.length === 0) {
-            checkEmptyState('No matching recommendations found');
+            checkNoMatchingRecs();
           } else {
             cy.get(`td[data-label="Description"]`)
               .then(($els) => {

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -261,10 +261,7 @@ describe('cluster rules table', () => {
       filterApply({
         description: 'Not existing recommendation',
       });
-      checkEmptyState(
-        'No matching recommendations found',
-        'To continue, edit your filter settings and search again.'
-      );
+      checkEmptyState('No matching recommendations found');
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -280,10 +277,7 @@ describe('cluster rules table', () => {
             ).sort();
             filterApply(filters);
             if (sortedDescriptions.length === 0) {
-              checkEmptyState(
-                'No matching recommendations found',
-                'To continue, edit your filter settings and search again.'
-              );
+              checkEmptyState('No matching recommendations found');
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Description"]`)
@@ -326,10 +320,7 @@ describe('cluster rules table', () => {
           ).sort();
           filterApply(filters);
           if (sortedDescriptions.length === 0) {
-            checkEmptyState(
-              'No matching recommendations found',
-              'To continue, edit your filter settings and search again.'
-            );
+            checkEmptyState('No matching recommendations found');
           } else {
             cy.get(`td[data-label="Description"]`)
               .then(($els) => {
@@ -401,7 +392,6 @@ describe('empty cluster rules table', () => {
   it('renders no recommendation message', () => {
     checkEmptyState(
       'The cluster is not affected by any known recommendations',
-      'No known recommendations affect this cluster.',
       true
     );
   });

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -75,6 +75,8 @@ const filterCombos = [
   { risk: ['Critical', 'Moderate'], category: ['Service Availability'] },
 ];
 
+// TODO: when checking empty state, also check toolbar available and not disabled
+
 describe('test data', () => {
   it('has rules', () => {
     expect(data).to.have.length.gte(1);

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -333,7 +333,6 @@ const ClustersListTable = ({
             filterConfig={{ items: filterConfigItems }}
             activeFiltersConfig={activeFiltersConfig}
           />
-          {loadingState && <Loading />}
           {errorState && (
             <Card ouiaId="error-state">
               <CardBody>
@@ -341,56 +340,54 @@ const ClustersListTable = ({
               </CardBody>
             </Card>
           )}
-          {!loadingState && successState && (
-            <React.Fragment>
-              <Table
-                aria-label="Table of clusters"
-                ouiaId="clusters"
-                variant={TableVariant.compact}
-                cells={CLUSTERS_LIST_COLUMNS}
-                rows={
-                  loadingState
-                    ? [
-                        {
-                          fullWidth: true,
-                          cells: [
-                            {
-                              props: {
-                                colSpan: CLUSTERS_LIST_COLUMNS.length + 1,
-                              },
-                              title: <List key="loading-cell" />,
+          <React.Fragment>
+            <Table
+              aria-label="Table of clusters"
+              ouiaId="clusters"
+              variant={TableVariant.compact}
+              cells={CLUSTERS_LIST_COLUMNS}
+              rows={
+                loadingState
+                  ? [
+                      {
+                        fullWidth: true,
+                        cells: [
+                          {
+                            props: {
+                              colSpan: CLUSTERS_LIST_COLUMNS.length + 1,
                             },
-                          ],
-                        },
-                      ]
-                    : clusters.length > 0 && filteredRows.length === 0
-                    ? [
-                        {
-                          fullWidth: true,
-                          cells: [
-                            {
-                              props: {
-                                colSpan: CLUSTERS_LIST_COLUMNS.length + 1,
-                              },
-                              title: <NoMatchingClusters />,
+                            title: <List key="loading-cell" />,
+                          },
+                        ],
+                      },
+                    ]
+                  : clusters.length > 0 && filteredRows.length === 0
+                  ? [
+                      {
+                        fullWidth: true,
+                        cells: [
+                          {
+                            props: {
+                              colSpan: CLUSTERS_LIST_COLUMNS.length + 1,
                             },
-                          ],
-                        },
-                      ]
-                    : displayedRows
-                }
-                sortBy={{
-                  index: filters.sortIndex,
-                  direction: filters.sortDirection,
-                }}
-                onSort={onSort}
-                isStickyHeader
-              >
-                <TableHeader />
-                <TableBody />
-              </Table>
-            </React.Fragment>
-          )}
+                            title: <NoMatchingClusters />,
+                          },
+                        ],
+                      },
+                    ]
+                  : displayedRows
+              }
+              sortBy={{
+                index: filters.sortIndex,
+                direction: filters.sortDirection,
+              }}
+              onSort={onSort}
+              isStickyHeader
+            >
+              <TableHeader />
+              <TableBody />
+            </Table>
+          </React.Fragment>
           <Pagination
             ouiaId="pager"
             itemCount={filteredRows.length}

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { useLocation } from 'react-router-dom';
+import { List } from 'react-content-loader';
 import uniqBy from 'lodash/uniqBy';
 import { valid } from 'semver';
 import { Link } from 'react-router-dom';
@@ -347,7 +348,37 @@ const ClustersListTable = ({
                 ouiaId="clusters"
                 variant={TableVariant.compact}
                 cells={CLUSTERS_LIST_COLUMNS}
-                rows={displayedRows}
+                rows={
+                  loadingState
+                    ? [
+                        {
+                          fullWidth: true,
+                          cells: [
+                            {
+                              props: {
+                                colSpan: CLUSTERS_LIST_COLUMNS.length + 1,
+                              },
+                              title: <List key="loading-cell" />,
+                            },
+                          ],
+                        },
+                      ]
+                    : clusters.length > 0 && filteredRows.length === 0
+                    ? [
+                        {
+                          fullWidth: true,
+                          cells: [
+                            {
+                              props: {
+                                colSpan: CLUSTERS_LIST_COLUMNS.length + 1,
+                              },
+                              title: <NoMatchingClusters />,
+                            },
+                          ],
+                        },
+                      ]
+                    : displayedRows
+                }
                 sortBy={{
                   index: filters.sortIndex,
                   direction: filters.sortDirection,
@@ -358,13 +389,6 @@ const ClustersListTable = ({
                 <TableHeader />
                 <TableBody />
               </Table>
-              {filteredRows.length === 0 && (
-                <Card ouiaId="empty-state">
-                  <CardBody>
-                    <NoMatchingClusters />
-                  </CardBody>
-                </Card>
-              )}
             </React.Fragment>
           )}
           <Pagination

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -300,7 +300,7 @@ const ClustersListTable = ({
 
   return (
     <>
-      {clusters.length === 0 ? (
+      {isSuccess && clusters.length === 0 ? (
         <NoRecsForClusters /> // TODO: do not mix this logic in the table component
       ) : (
         <div id="clusters-list-table">

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -34,6 +34,7 @@ import {
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
+  checkNoMatchState,
 } from '../../../cypress/utils/table';
 import { CLUSTERS_LIST_COLUMNS } from '../../AppConstants';
 import {
@@ -411,8 +412,8 @@ describe('clusters list table', () => {
         name: 'Not existing clusters',
         risk: ['Critical', 'Moderate'],
       });
-      // TODO check empty table view
-      // TODO headers are displayed
+      checkNoMatchState();
+      checkTableHeaders(TABLE_HEADERS);
     });
 
     describe('single filter', () => {
@@ -428,8 +429,8 @@ describe('clusters list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              // TODO check empty table view
-              // TODO headers are displayed
+              checkNoMatchState();
+              checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
                 .then(($els) => {
@@ -485,7 +486,7 @@ describe('clusters list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            // TODO check empty table view
+            checkNoMatchState();
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -414,10 +414,7 @@ describe('clusters list table', () => {
         name: 'Not existing clusters',
         risk: ['Critical', 'Moderate'],
       });
-      checkEmptyState(
-        'No matching clusters found',
-        'To continue, edit your filter settings and search again.'
-      );
+      checkEmptyState('No matching clusters found');
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -434,10 +431,7 @@ describe('clusters list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkEmptyState(
-                'No matching clusters found',
-                'To continue, edit your filter settings and search again.'
-              );
+              checkEmptyState('No matching clusters found');
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -494,10 +488,7 @@ describe('clusters list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkEmptyState(
-              'No matching clusters found',
-              'To continue, edit your filter settings and search again.'
-            );
+            checkEmptyState('No matching clusters found');
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -34,7 +34,7 @@ import {
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
-  checkEmptyState,
+  checkNoMatchingClusters,
 } from '../../../cypress/utils/table';
 import { CLUSTERS_LIST_COLUMNS } from '../../AppConstants';
 import {
@@ -414,7 +414,7 @@ describe('clusters list table', () => {
         name: 'Not existing clusters',
         risk: ['Critical', 'Moderate'],
       });
-      checkEmptyState('No matching clusters found');
+      checkNoMatchingClusters();
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -431,7 +431,7 @@ describe('clusters list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkEmptyState('No matching clusters found');
+              checkNoMatchingClusters();
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -488,7 +488,7 @@ describe('clusters list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkEmptyState('No matching clusters found');
+            checkNoMatchingClusters();
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -137,6 +137,8 @@ const filterCombos = [{ risk: ['Critical', 'Moderate'], name: 'foo' }];
 
 // TODO use filterData in all tests except of data or namedClusters or namedClustersDefaultSorting
 
+// TODO: when checking empty state, also check toolbar available and not disabled
+
 describe('data', () => {
   it('has values', () => {
     expect(filterData(data)).to.have.length.gte(1);

--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -34,7 +34,7 @@ import {
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
-  checkNoMatchState,
+  checkEmptyState,
 } from '../../../cypress/utils/table';
 import { CLUSTERS_LIST_COLUMNS } from '../../AppConstants';
 import {
@@ -412,7 +412,10 @@ describe('clusters list table', () => {
         name: 'Not existing clusters',
         risk: ['Critical', 'Moderate'],
       });
-      checkNoMatchState();
+      checkEmptyState(
+        'No matching clusters found',
+        'To continue, edit your filter settings and search again.'
+      );
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -429,7 +432,10 @@ describe('clusters list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkNoMatchState();
+              checkEmptyState(
+                'No matching clusters found',
+                'To continue, edit your filter settings and search again.'
+              );
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -486,7 +492,10 @@ describe('clusters list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkNoMatchState();
+            checkEmptyState(
+              'No matching clusters found',
+              'To continue, edit your filter settings and search again.'
+            );
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {

--- a/src/Components/Loading/Loading.js
+++ b/src/Components/Loading/Loading.js
@@ -1,18 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Card, CardBody } from '@patternfly/react-core';
 import { List } from 'react-content-loader';
 
-const Loading = ({ id }) => (
-  <Card {...(id ? { id } : {})}>
+const Loading = () => (
+  <Card ouiaId="loading-skeleton">
     <CardBody>
       <List />
     </CardBody>
   </Card>
 );
-
-Loading.propTypes = {
-  id: PropTypes.string,
-};
 
 export default Loading;

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -15,6 +15,9 @@ import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-ic
 import { global_success_color_100 as globalSuccessColor100 } from '@patternfly/react-tokens/dist/js/global_success_color_100';
 import { global_danger_color_100 as globalDangerColor100 } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import { InProgressIcon } from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
+import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
+import { global_info_color_100 as globalInfoColor100 } from '@patternfly/react-tokens/dist/js/global_info_color_100.js';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
 
 import DefaultErrorMessage from '@redhat-cloud-services/frontend-components/ErrorState/DefaultErrorMessage';
 
@@ -132,6 +135,57 @@ const NoRecsForClusters = () => {
   );
 };
 
+const NoInsightsResults = () => {
+  const intl = useIntl();
+  return (
+    <MessageState
+      title={intl.formatMessage(messages.noRecsFoundError)}
+      text={
+        <React.Fragment>
+          {intl.formatMessage(messages.noRecsFoundErrorDesc)}
+          <a href="https://docs.openshift.com/container-platform/latest/support/getting-support.html">
+            {' '}
+            OpenShift documentation.
+          </a>
+        </React.Fragment>
+      }
+      icon={InfoCircleIcon}
+      iconStyle={{
+        color: globalInfoColor100.value,
+      }}
+      variant="large"
+    />
+  );
+};
+
+const NoRecsError = () => {
+  const intl = useIntl();
+  return (
+    <MessageState
+      title={intl.formatMessage(messages.noRecsError)}
+      text={intl.formatMessage(messages.noRecsErrorDesc)}
+      icon={ExclamationCircleIcon}
+      iconStyle={{
+        color: globalDangerColor100.value,
+      }}
+    />
+  );
+};
+
+const NoRecsAffecting = () => {
+  const intl = useIntl();
+  return (
+    <MessageState
+      icon={CheckIcon}
+      iconStyle={{
+        color: globalSuccessColor100.value,
+      }}
+      title={intl.formatMessage(messages.noRecommendations)}
+      text={intl.formatMessage(messages.noRecommendationsDesc)}
+    />
+  );
+};
+
 export {
   ErrorState,
   NoAffectedClusters,
@@ -139,4 +193,7 @@ export {
   NoMatchingRecs,
   ComingSoon,
   NoRecsForClusters,
+  NoInsightsResults,
+  NoRecsError,
+  NoRecsAffecting,
 };

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -26,23 +26,19 @@ import messages from '../../Messages';
 const ErrorState = () => {
   const intl = useIntl();
   return (
-    <EmptyState>
-      <EmptyStateIcon
-        icon={ExclamationCircleIcon}
-        color={globalDangerColor100.value}
-      />
-      <Title headingLevel="h4" size="lg">
-        {intl.formatMessage(messages.errorStateTitle)}
-      </Title>
-      <EmptyStateBody>
+    <MessageState
+      title={intl.formatMessage(messages.errorStateTitle)}
+      text={
         <Stack>
           <StackItem>{intl.formatMessage(messages.errorStateBody)}</StackItem>
           <StackItem>
             <DefaultErrorMessage />
           </StackItem>
         </Stack>
-      </EmptyStateBody>
-    </EmptyState>
+      }
+      icon={ExclamationCircleIcon}
+      iconStyle={{ color: globalDangerColor100.value }}
+    />
   );
 };
 

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -80,8 +80,6 @@ const NoMatchingRecs = () => {
     <MessageState
       title={intl.formatMessage(messages.noMatchingRecsTitle)}
       text={intl.formatMessage(messages.noMatchingRecsBody)}
-      icon={CheckCircleIcon}
-      iconStyle={{ color: globalSuccessColor100.value }}
     />
   );
 };

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -67,14 +67,10 @@ const NoAffectedClusters = () => {
 const NoMatchingClusters = () => {
   const intl = useIntl();
   return (
-    <EmptyState>
-      <Title headingLevel="h5" size="lg">
-        {intl.formatMessage(messages.noMatchingClustersTitle)}
-      </Title>
-      <EmptyStateBody>
-        {intl.formatMessage(messages.noMatchingClustersBody)}
-      </EmptyStateBody>
-    </EmptyState>
+    <MessageState
+      title={intl.formatMessage(messages.noMatchingClustersTitle)}
+      text={intl.formatMessage(messages.noMatchingClustersBody)}
+    />
   );
 };
 // used in the recs list table: no filters match

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -49,18 +49,12 @@ const ErrorState = () => {
 const NoAffectedClusters = () => {
   const intl = useIntl();
   return (
-    <EmptyState>
-      <EmptyStateIcon
-        icon={CheckCircleIcon}
-        color={globalSuccessColor100.value}
-      />
-      <Title headingLevel="h4" size="lg">
-        {intl.formatMessage(messages.noAffectedClustersTitle)}
-      </Title>
-      <EmptyStateBody>
-        {intl.formatMessage(messages.noAffectedClustersBody)}
-      </EmptyStateBody>
-    </EmptyState>
+    <MessageState
+      title={intl.formatMessage(messages.noAffectedClustersTitle)}
+      text={intl.formatMessage(messages.noAffectedClustersBody)}
+      icon={CheckCircleIcon}
+      iconStyle={{ color: globalSuccessColor100.value }}
+    />
   );
 };
 

--- a/src/Components/MessageState/MessageState.js
+++ b/src/Components/MessageState/MessageState.js
@@ -20,7 +20,7 @@ const MessageState = ({
   title,
   variant,
 }) => (
-  <EmptyState className={className} variant={variant}>
+  <EmptyState className={className} variant={variant} ouiaId="empty-state">
     {icon !== 'none' && (
       <EmptyStateIcon className={iconClass} style={iconStyle} icon={icon} />
     )}

--- a/src/Components/MessageState/MessageState.js
+++ b/src/Components/MessageState/MessageState.js
@@ -21,7 +21,7 @@ const MessageState = ({
   variant,
 }) => (
   <EmptyState className={className} variant={variant} ouiaId="empty-state">
-    {icon !== 'none' && (
+    {icon && (
       <EmptyStateIcon className={iconClass} style={iconStyle} icon={icon} />
     )}
     <Title headingLevel="h5" size="lg">
@@ -44,7 +44,6 @@ MessageState.propTypes = {
 };
 
 MessageState.defaultProps = {
-  icon: CubesIcon,
   title: '',
   variant: EmptyStateVariant.full,
 };

--- a/src/Components/MessageState/MessageState.js
+++ b/src/Components/MessageState/MessageState.js
@@ -1,6 +1,5 @@
 import { EmptyStateVariant } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyState';
 
-import CubesIcon from '@patternfly/react-icons/dist/js/icons/cubes-icon';
 import {
   EmptyStateIcon,
   EmptyStateBody,

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -614,7 +614,7 @@ const RecsListTable = ({ query }) => {
                       fullWidth: true,
                       cells: [
                         {
-                          props: { colSpan: 5 },
+                          props: { colSpan: RECS_LIST_COLUMNS.length + 1 },
                           title: <List key="loading-cell" />,
                         },
                       ],
@@ -626,7 +626,7 @@ const RecsListTable = ({ query }) => {
                       fullWidth: true,
                       cells: [
                         {
-                          props: { colSpan: 5 },
+                          props: { colSpan: RECS_LIST_COLUMNS.length + 1 },
                           title: <NoMatchingRecs ouiaId="empty-state" />,
                         },
                       ],

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -620,7 +620,7 @@ const RecsListTable = ({ query }) => {
             <ErrorState />
           )
         }
-        onCollapse={handleOnCollapse}
+        onCollapse={handleOnCollapse} // TODO: set undefined when there is an empty state
         sortBy={{
           index: filters.sortIndex,
           direction: filters.sortDirection,

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -13,13 +13,7 @@ import {
   TableHeader,
   TableVariant,
 } from '@patternfly/react-table';
-import {
-  Pagination,
-  Stack,
-  Card,
-  CardBody,
-  Tooltip,
-} from '@patternfly/react-core';
+import { Pagination, Stack, Tooltip } from '@patternfly/react-core';
 import { TooltipPosition } from '@patternfly/react-core/dist/js/components/Tooltip';
 import { PaginationVariant } from '@patternfly/react-core/dist/js/components/Pagination/Pagination';
 import isEqual from 'lodash/isEqual';
@@ -46,7 +40,6 @@ import {
   mapContentToValues,
   strong,
 } from '../../Utilities/intlHelper';
-import { List } from 'react-content-loader';
 import { ErrorState, NoMatchingRecs } from '../MessageState/EmptyStates';
 import {
   passFilters,
@@ -66,6 +59,7 @@ import {
   RuleDetailsMessagesKeys,
 } from '@redhat-cloud-services/frontend-components-advisor-components';
 import { adjustOCPRule } from '../../Utilities/Rule';
+import Loading from '../Loading/Loading';
 
 const RecsListTable = ({ query }) => {
   const intl = useIntl();
@@ -92,6 +86,7 @@ const RecsListTable = ({ query }) => {
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError || (isSuccess && recs.length === 0);
   const successState = isSuccess && recs.length > 0;
+  const noMatch = recs.length > 0 && filteredRows.length === 0;
 
   const removeFilterParam = (param) =>
     _removeFilterParam(filters, updateFilters, param);
@@ -593,62 +588,51 @@ const RecsListTable = ({ query }) => {
         }}
         activeFiltersConfig={errorState ? undefined : activeFiltersConfig}
       />
-      {errorState && (
-        <Card id="error-state-message" ouiaId="error-state">
-          <CardBody>
+      <Table
+        aria-label="Table of recommendations"
+        ouiaId="recommendations"
+        variant={TableVariant.compact}
+        cells={RECS_LIST_COLUMNS}
+        rows={
+          errorState || loadingState || noMatch ? (
+            [
+              {
+                fullWidth: true,
+                cells: [
+                  {
+                    props: {
+                      colSpan: RECS_LIST_COLUMNS.length + 1,
+                    },
+                    title: errorState ? (
+                      <ErrorState />
+                    ) : loadingState ? (
+                      <Loading />
+                    ) : (
+                      <NoMatchingRecs />
+                    ),
+                  },
+                ],
+              },
+            ]
+          ) : successState ? (
+            displayedRows
+          ) : (
             <ErrorState />
-          </CardBody>
-        </Card>
-      )}
-      {(loadingState || successState) && (
-        <React.Fragment>
-          <Table
-            aria-label="Table of recommendations"
-            ouiaId="recommendations"
-            variant={TableVariant.compact}
-            cells={RECS_LIST_COLUMNS}
-            rows={
-              loadingState
-                ? [
-                    {
-                      fullWidth: true,
-                      cells: [
-                        {
-                          props: { colSpan: RECS_LIST_COLUMNS.length + 1 },
-                          title: <List key="loading-cell" />,
-                        },
-                      ],
-                    },
-                  ]
-                : recs.length > 0 && filteredRows.length === 0
-                ? [
-                    {
-                      fullWidth: true,
-                      cells: [
-                        {
-                          props: { colSpan: RECS_LIST_COLUMNS.length + 1 },
-                          title: <NoMatchingRecs ouiaId="empty-state" />,
-                        },
-                      ],
-                    },
-                  ]
-                : displayedRows
-            }
-            onCollapse={handleOnCollapse}
-            sortBy={{
-              index: filters.sortIndex,
-              direction: filters.sortDirection,
-            }}
-            onSort={onSort}
-            actionResolver={actionResolver}
-            isStickyHeader
-            ouiaSafe={testSafe}
-          >
-            <TableHeader />
-            <TableBody />
-          </Table>
-        </React.Fragment>
-      )}
+          )
+        }
+        onCollapse={handleOnCollapse}
+        sortBy={{
+          index: filters.sortIndex,
+          direction: filters.sortDirection,
+        }}
+        onSort={onSort}
+        actionResolver={actionResolver}
+        isStickyHeader
+        ouiaSafe={testSafe}
+      >
+        <TableHeader />
+        <TableBody />
+      </Table>
       <Pagination
         ouiaId="pager"
         itemCount={filteredRows.length}

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -660,7 +660,7 @@ RecsListTable.propTypes = {
     isUninitialized: PropTypes.bool.isRequired,
     isFetching: PropTypes.bool.isRequired,
     isSuccess: PropTypes.bool.isRequired,
-    data: PropTypes.array,
+    data: PropTypes.object,
     refetch: PropTypes.func,
   }),
 };

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -202,6 +202,8 @@ before(() => {
 
 // TODO test data
 
+// TODO: when checking empty state, also check toolbar available and not disabled
+
 describe('data', () => {
   it('has values', () => {
     expect(data).to.have.length.gte(1);

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -15,6 +15,7 @@ import {
   CHIP_GROUP,
   PAGINATION,
   TABLE,
+  TITLE,
 } from '../../../cypress/utils/components';
 import {
   hasChip,
@@ -158,6 +159,20 @@ const DEFAULT_DISPLAYED_SIZE = Math.min(
 );
 
 const filterCombos = [{ impacting: ['1 or more'] }];
+
+const checkEmptyState = () => {
+  cy.get('[ouiaid=empty-state]').within(() => {
+    cy.get('.pf-c-empty-state__icon').should('have.length', 1);
+    cy.get(`h5${TITLE}`).should(
+      'have.text',
+      'No matching recommendations found'
+    );
+    cy.get('.pf-c-empty-state__body').should(
+      'have.text',
+      'To continue, edit your filter settings and search again.'
+    );
+  });
+};
 
 // actions
 Cypress.Commands.add('getAllRows', () => cy.get(TABLE).find(ROW));
@@ -537,8 +552,8 @@ describe('successful non-empty recommendations list table', () => {
       filterApply({
         name: 'Not existing recommendation',
       });
-      // TODO check empty table view
-      // TODO headers are displayed
+      checkEmptyState();
+      checkTableHeaders(TABLE_HEADERS);
     });
 
     it('no filters show all recommendations', () => {
@@ -564,8 +579,8 @@ describe('successful non-empty recommendations list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              // TODO check empty table view
-              // TODO headers are displayed
+              checkEmptyState();
+              checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
                 .then(($els) => {
@@ -614,6 +629,7 @@ describe('successful non-empty recommendations list table', () => {
       });
     });
 
+    // TODO: add more combinations
     describe('combined filters', () => {
       filterCombos.forEach((filters) => {
         it(`${Object.keys(filters)}`, () => {
@@ -628,7 +644,8 @@ describe('successful non-empty recommendations list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            // TODO check empty table view
+            checkEmptyState();
+            checkTableHeaders(TABLE_HEADERS);
           } else {
             cy.get(`td[data-label="Name"]`)
               .then(($els) => {

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -41,7 +41,7 @@ import {
   columnName2UrlParam,
   checkTableHeaders,
   tableIsSortedBy,
-  checkNoMatchState,
+  checkEmptyState,
 } from '../../../cypress/utils/table';
 import { SORTING_ORDERS } from '../../../cypress/utils/globals';
 // TODO make more use of ../../../cypress/utils/components
@@ -538,7 +538,10 @@ describe('successful non-empty recommendations list table', () => {
       filterApply({
         name: 'Not existing recommendation',
       });
-      checkNoMatchState(true);
+      checkEmptyState(
+        'No matching recommendations found',
+        'To continue, edit your filter settings and search again.'
+      );
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -565,7 +568,10 @@ describe('successful non-empty recommendations list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkNoMatchState(true);
+              checkEmptyState(
+                'No matching recommendations found',
+                'To continue, edit your filter settings and search again.'
+              );
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -630,7 +636,10 @@ describe('successful non-empty recommendations list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkNoMatchState(true);
+            checkEmptyState(
+              'No matching recommendations found',
+              'To continue, edit your filter settings and search again.'
+            );
             checkTableHeaders(TABLE_HEADERS);
           } else {
             cy.get(`td[data-label="Name"]`)

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -42,6 +42,7 @@ import {
   checkTableHeaders,
   tableIsSortedBy,
   checkEmptyState,
+  checkNoMatchingRecs,
 } from '../../../cypress/utils/table';
 import { SORTING_ORDERS } from '../../../cypress/utils/globals';
 // TODO make more use of ../../../cypress/utils/components
@@ -540,7 +541,7 @@ describe('successful non-empty recommendations list table', () => {
       filterApply({
         name: 'Not existing recommendation',
       });
-      checkEmptyState('No matching recommendations found');
+      checkNoMatchingRecs();
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -567,7 +568,7 @@ describe('successful non-empty recommendations list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkEmptyState('No matching recommendations found');
+              checkNoMatchingRecs();
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -632,7 +633,7 @@ describe('successful non-empty recommendations list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkEmptyState('No matching recommendations found');
+            checkNoMatchingRecs();
             checkTableHeaders(TABLE_HEADERS);
           } else {
             cy.get(`td[data-label="Name"]`)

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -15,7 +15,6 @@ import {
   CHIP_GROUP,
   PAGINATION,
   TABLE,
-  TITLE,
 } from '../../../cypress/utils/components';
 import {
   hasChip,
@@ -42,6 +41,7 @@ import {
   columnName2UrlParam,
   checkTableHeaders,
   tableIsSortedBy,
+  checkNoMatchState,
 } from '../../../cypress/utils/table';
 import { SORTING_ORDERS } from '../../../cypress/utils/globals';
 // TODO make more use of ../../../cypress/utils/components
@@ -159,20 +159,6 @@ const DEFAULT_DISPLAYED_SIZE = Math.min(
 );
 
 const filterCombos = [{ impacting: ['1 or more'] }];
-
-const checkEmptyState = () => {
-  cy.get('[ouiaid=empty-state]').within(() => {
-    cy.get('.pf-c-empty-state__icon').should('have.length', 1);
-    cy.get(`h5${TITLE}`).should(
-      'have.text',
-      'No matching recommendations found'
-    );
-    cy.get('.pf-c-empty-state__body').should(
-      'have.text',
-      'To continue, edit your filter settings and search again.'
-    );
-  });
-};
 
 // actions
 Cypress.Commands.add('getAllRows', () => cy.get(TABLE).find(ROW));
@@ -552,7 +538,7 @@ describe('successful non-empty recommendations list table', () => {
       filterApply({
         name: 'Not existing recommendation',
       });
-      checkEmptyState();
+      checkNoMatchState(true);
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -579,7 +565,7 @@ describe('successful non-empty recommendations list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkEmptyState();
+              checkNoMatchState(true);
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -644,7 +630,7 @@ describe('successful non-empty recommendations list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkEmptyState();
+            checkNoMatchState(true);
             checkTableHeaders(TABLE_HEADERS);
           } else {
             cy.get(`td[data-label="Name"]`)

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -795,9 +795,11 @@ describe('empty recommendations list table', () => {
   });
 
   it('renders error message', () => {
-    cy.get('#error-state-message')
-      .find('h4')
-      .should('have.text', 'Something went wrong');
+    checkEmptyState(
+      'Something went wrong',
+      'There was a problem processing the request. Please try again.If the problem persists, contact Red Hat Support or check our  status page for known outages.',
+      true
+    ); // error is shown because it is not OK if API responds 200 but with no recommendations
   });
 });
 
@@ -823,8 +825,10 @@ describe('error recommendations list table', () => {
   });
 
   it('renders error message', () => {
-    cy.get('#error-state-message')
-      .find('h4')
-      .should('have.text', 'Something went wrong');
+    checkEmptyState(
+      'Something went wrong',
+      'There was a problem processing the request. Please try again.If the problem persists, contact Red Hat Support or check our  status page for known outages.',
+      true
+    );
   });
 });

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -540,10 +540,7 @@ describe('successful non-empty recommendations list table', () => {
       filterApply({
         name: 'Not existing recommendation',
       });
-      checkEmptyState(
-        'No matching recommendations found',
-        'To continue, edit your filter settings and search again.'
-      );
+      checkEmptyState('No matching recommendations found');
       checkTableHeaders(TABLE_HEADERS);
     });
 
@@ -570,10 +567,7 @@ describe('successful non-empty recommendations list table', () => {
             removeAllChips();
             filterApply(filters);
             if (sortedNames.length === 0) {
-              checkEmptyState(
-                'No matching recommendations found',
-                'To continue, edit your filter settings and search again.'
-              );
+              checkEmptyState('No matching recommendations found');
               checkTableHeaders(TABLE_HEADERS);
             } else {
               cy.get(`td[data-label="Name"]`)
@@ -638,10 +632,7 @@ describe('successful non-empty recommendations list table', () => {
           removeAllChips();
           filterApply(filters);
           if (sortedNames.length === 0) {
-            checkEmptyState(
-              'No matching recommendations found',
-              'To continue, edit your filter settings and search again.'
-            );
+            checkEmptyState('No matching recommendations found');
             checkTableHeaders(TABLE_HEADERS);
           } else {
             cy.get(`td[data-label="Name"]`)
@@ -797,11 +788,7 @@ describe('empty recommendations list table', () => {
   });
 
   it('renders error message', () => {
-    checkEmptyState(
-      'Something went wrong',
-      'There was a problem processing the request. Please try again.If the problem persists, contact Red Hat Support or check our  status page for known outages.',
-      true
-    ); // error is shown because it is not OK if API responds 200 but with no recommendations
+    checkEmptyState('Something went wrong', true); // error is shown because it is not OK if API responds 200 but with no recommendations
   });
 });
 
@@ -827,10 +814,6 @@ describe('error recommendations list table', () => {
   });
 
   it('renders error message', () => {
-    checkEmptyState(
-      'Something went wrong',
-      'There was a problem processing the request. Please try again.If the problem persists, contact Red Hat Support or check our  status page for known outages.',
-      true
-    );
+    checkEmptyState('Something went wrong', true);
   });
 });

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -246,7 +246,7 @@ export default defineMessages({
   noRecsError: {
     id: 'noRecsError',
     description: 'Recommendations table, cluster recommendations table',
-    defaultMessage: 'No recommendations available.',
+    defaultMessage: 'No recommendations available',
   },
   noRecsErrorDesc: {
     id: 'noRecsErrorDesc',


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/CCXDEV-8280, https://issues.redhat.com/browse/CCXDEV-8242

Mainly refactors how table components are handling empty states. Also adds tests to check that the empty state titles, messages, and icons are rendered correctly.

- [x] Test "no match" empty states in each table
- [x] Check headers always displayed
- [x] Check icons are not rendered (only title and text body): https://marvelapp.com/prototype/g70a1he/screen/82026901

Some illustrations:

![Screenshot 2022-06-03 at 15-53-02 37556893-a47d-4b14-8e8b-e0f741f7df4f - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/171867857-6d1e3083-12e5-48e4-8571-8f9c1984f21d.png)
![Screenshot 2022-06-03 at 15-52-30 No Issues Cluster - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/171867864-44c40651-9c35-4618-92c9-baedcc9485c5.png)
![Screenshot 2022-06-03 at 15-52-17 Test disable recommendation - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/171867866-1c07de87-d18e-4a14-9770-d3d28a4039f9.png)
![Screenshot 2022-06-03 at 15-51-59 Recommendations - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/171867867-4c9aa696-390e-4b21-bdcd-e3581f17bd13.png)
![Screenshot 2022-06-03 at 15-51-45 Data loss will happen when a machine object is deleted that maps to a 'NotReady' node with attached VMDK volumes - Recommendations - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/171867868-6547623f-6517-456f-912c-7eb9e44ed4cc.png)
