### PR TITLE
Fix wrong placement of "Expand all" button in tables

### DIFF
--- a/cypress/utils/components.js
+++ b/cypress/utils/components.js
@@ -15,6 +15,7 @@ const DROPDOWN_ITEM = '[data-ouia-component-type="PF4/DropdownItem"]';
 const TBODY = 'tbody[role=rowgroup]';
 const TOOLBAR_FILTER = '.ins-c-primary-toolbar__filter';
 const TABLE = 'table';
+const TABLE_HEADER = 'thead';
 
 const ouiaId = (id) => `[data-ouia-component-id="${id}"]`;
 
@@ -35,4 +36,5 @@ export {
   TBODY,
   TOOLBAR_FILTER,
   TABLE,
+  TABLE_HEADER,
 };

--- a/cypress/utils/components.js
+++ b/cypress/utils/components.js
@@ -16,6 +16,7 @@ const TBODY = 'tbody[role=rowgroup]';
 const TOOLBAR_FILTER = '.ins-c-primary-toolbar__filter';
 const TABLE = 'table';
 const TABLE_HEADER = 'thead';
+const ROWS_TOGGLER = `${TABLE_HEADER} .pf-c-table__toggle`;
 
 const ouiaId = (id) => `[data-ouia-component-id="${id}"]`;
 
@@ -37,4 +38,5 @@ export {
   TOOLBAR_FILTER,
   TABLE,
   TABLE_HEADER,
+  ROWS_TOGGLER,
 };

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { ROW, TBODY } from './components';
+import { ROW, TABLE_HEADER, TBODY } from './components';
 
 function checkTableHeaders(expectedHeaders) {
   /* patternfly/react-table-4.71.16, for some reason, renders extra empty `th` container;
@@ -33,9 +33,14 @@ function tableIsSortedBy(columnTitle) {
     .should('have.class', 'pf-c-table__sort pf-m-selected');
 }
 
+function expandAllRows() {
+  return cy.get(`${TABLE_HEADER} .pf-c-table__toggle`).click();
+}
+
 export {
   checkTableHeaders,
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
+  expandAllRows,
 };

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -33,14 +33,9 @@ function tableIsSortedBy(columnTitle) {
     .should('have.class', 'pf-c-table__sort pf-m-selected');
 }
 
-function expandAllRows() {
-  return cy.get(`${TABLE_HEADER} .pf-c-table__toggle`).click();
-}
-
 export {
   checkTableHeaders,
   checkRowCounts,
   columnName2UrlParam,
   tableIsSortedBy,
-  expandAllRows,
 };

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -125,9 +125,22 @@ const ClusterRules = ({ cluster }) => {
   }, [rowsFiltered]);
 
   const handleOnCollapse = (_e, rowId, isOpen) => {
-    const collapseRows = [...displayedRows];
-    collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
-    setDisplayedRows(collapseRows);
+    if (rowId === undefined) {
+      // if undefined, all rows are affected
+      setIsAllExpanded(isOpen);
+      setDisplayedRows(
+        displayedRows.map((row) => ({
+          ...row,
+          isOpen: isOpen,
+        }))
+      );
+    } else {
+      setDisplayedRows(
+        displayedRows.map((row, index) =>
+          index === rowId ? { ...row, isOpen } : row
+        )
+      );
+    }
   };
 
   const buildFilteredRows = (allRows, filters) => {
@@ -379,24 +392,9 @@ const ClusterRules = ({ cluster }) => {
     },
   };
 
-  //Responsible for the handling collapse for all the recommendations
-  //Used in the PrimaryToolbar
-  const collapseAll = (_e, isOpen) => {
-    setIsAllExpanded(isOpen);
-    setDisplayedRows(
-      displayedRows.map((row) => {
-        return {
-          ...row,
-          isOpen: isOpen,
-        };
-      })
-    );
-  };
-
   return (
     <div id="cluster-recs-list-table">
       <PrimaryToolbar
-        expandAll={{ isAllExpanded, onClick: collapseAll }}
         filterConfig={{
           items: filterConfigItems,
           isDisabled: loadingState || errorState || reports.length === 0,
@@ -460,6 +458,7 @@ const ClusterRules = ({ cluster }) => {
                 onSort={onSort}
                 variant={TableVariant.compact}
                 isStickyHeader
+                canCollapseAll
               >
                 <TableHeader />
                 <TableBody />

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -17,13 +17,14 @@ import {
 } from '../../../cypress/utils/globals';
 import { applyFilters, filter } from '../../../cypress/utils/filters';
 import { cumulativeCombinations } from '../../../cypress/utils/combine';
-import { checkTableHeaders, expandAllRows } from '../../../cypress/utils/table';
+import { checkTableHeaders } from '../../../cypress/utils/table';
 import {
   CHIP_GROUP,
   CHIP,
   ROW,
   TOOLBAR,
   TABLE,
+  ROWS_TOGGLER,
 } from '../../../cypress/utils/components';
 
 const data = singleClusterPageReport.report.data;
@@ -177,9 +178,9 @@ describe('cluster rules table', () => {
   });
 
   it('expand all, collapse all', () => {
-    expandAllRows();
+    cy.get(ROWS_TOGGLER).click();
     cy.get(EXPANDABLES).should('have.length', RULES_ENABLED);
-    expandAllRows();
+    cy.get(ROWS_TOGGLER).click();
     cy.get(EXPANDABLES).should('have.length', 0);
   });
 

--- a/src/Components/ClusterRules/ClusterRules.spec.ct.js
+++ b/src/Components/ClusterRules/ClusterRules.spec.ct.js
@@ -17,7 +17,7 @@ import {
 } from '../../../cypress/utils/globals';
 import { applyFilters, filter } from '../../../cypress/utils/filters';
 import { cumulativeCombinations } from '../../../cypress/utils/combine';
-import { checkTableHeaders } from '../../../cypress/utils/table';
+import { checkTableHeaders, expandAllRows } from '../../../cypress/utils/table';
 import {
   CHIP_GROUP,
   CHIP,
@@ -177,11 +177,9 @@ describe('cluster rules table', () => {
   });
 
   it('expand all, collapse all', () => {
-    const TOOLBAR = '[class="pf-c-toolbar__item"]';
-
-    cy.get(TOOLBAR).find('button').click();
+    expandAllRows();
     cy.get(EXPANDABLES).should('have.length', RULES_ENABLED);
-    cy.get(TOOLBAR).find('button').click();
+    expandAllRows();
     cy.get(EXPANDABLES).should('have.length', 0);
   });
 

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -474,25 +474,23 @@ const RecsListTable = ({ query }) => {
     },
   };
 
-  //Responsible for the handling collapse for all the recommendations
-  //Used in the PrimaryToolbar
-  const collapseAll = (_e, isOpen) => {
-    setIsAllExpanded(isOpen);
-    setDisplayedRows(
-      displayedRows.map((row) => {
-        return {
+  const handleOnCollapse = (_e, rowId, isOpen) => {
+    if (rowId === undefined) {
+      // if undefined, all rows are affected
+      setIsAllExpanded(isOpen);
+      setDisplayedRows(
+        displayedRows.map((row) => ({
           ...row,
           isOpen: isOpen,
-        };
-      })
-    );
-  };
-
-  //Responsible for handling collapse for single recommendation
-  const handleOnCollapse = (_e, rowId, isOpen) => {
-    const collapseRows = [...displayedRows];
-    collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
-    setDisplayedRows(collapseRows);
+        }))
+      );
+    } else {
+      setDisplayedRows(
+        displayedRows.map((row, index) =>
+          index === rowId ? { ...row, isOpen } : row
+        )
+      );
+    }
   };
 
   const ackRule = async (rowId) => {
@@ -568,7 +566,6 @@ const RecsListTable = ({ query }) => {
         />
       )}
       <PrimaryToolbar
-        expandAll={{ isAllExpanded, onClick: collapseAll }}
         pagination={{
           itemCount: filteredRows.length,
           page: filters.offset / filters.limit + 1,
@@ -643,6 +640,7 @@ const RecsListTable = ({ query }) => {
             actionResolver={actionResolver}
             isStickyHeader
             ouiaSafe={testSafe}
+            canCollapseAll
           >
             <TableHeader />
             <TableBody />

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -15,6 +15,7 @@ import {
   CHIP_GROUP,
   PAGINATION,
   TABLE,
+  ROWS_TOGGLER,
 } from '../../../cypress/utils/components';
 import {
   hasChip,
@@ -41,7 +42,6 @@ import {
   columnName2UrlParam,
   checkTableHeaders,
   tableIsSortedBy,
-  expandAllRows,
 } from '../../../cypress/utils/table';
 import { SORTING_ORDERS } from '../../../cypress/utils/globals';
 // TODO make more use of ../../../cypress/utils/components
@@ -741,7 +741,7 @@ describe('successful non-empty recommendations list table', () => {
   });
 
   it('rule content is rendered', () => {
-    expandAllRows();
+    cy.get(ROWS_TOGGLER).click();
     cy.get(TABLE)
       .find('.pf-c-table__expandable-row.pf-m-expanded')
       .each((el) => {

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -41,6 +41,7 @@ import {
   columnName2UrlParam,
   checkTableHeaders,
   tableIsSortedBy,
+  expandAllRows,
 } from '../../../cypress/utils/table';
 import { SORTING_ORDERS } from '../../../cypress/utils/globals';
 // TODO make more use of ../../../cypress/utils/components
@@ -740,8 +741,7 @@ describe('successful non-empty recommendations list table', () => {
   });
 
   it('rule content is rendered', () => {
-    // expand all rules
-    cy.get('.pf-c-toolbar__expand-all-icon > svg').click();
+    expandAllRows();
     cy.get(TABLE)
       .find('.pf-c-table__expandable-row.pf-m-expanded')
       .each((el) => {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-8191.

Moves the "arrow" button for expanding/hovering all rows from the toolbar to table headers.

![Screenshot 2022-06-06 at 16-10-17 Cluster With Issues - Clusters - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/172177673-713ae7d9-3877-4ca2-85ae-8b9eb68bf4cc.png)

![Screenshot 2022-06-06 at 16-10-24 Recommendations - OCP Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/172177671-19988a51-8f67-4109-8d8f-c7f17a76c3c4.png)
