### PR TITLE
fix(Cluster reports): fix infinite table re-render when there are no rules

### DIFF
--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -105,7 +105,7 @@ const ClusterRules = ({ cluster }) => {
 
   useEffect(() => {
     setFilteredRows(buildFilteredRows(reports, filters));
-  }, [reports, filters]);
+  }, [data, filters]);
 
   useEffect(() => {
     setDisplayedRows(


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-8272.

The table, to update `filteredRows`, must look at the RTQ query data, not the state variable `reports`. The infinite re-render was triggered by the fact that even though previous and current states had `reports` equal to an empty array, from a JS perspective, they are perceived as different objects ([] === [] ~> false).