### PR TITLE
test(Pagination check): nest checkRowCounts within "then" callback

### DIFF
--- a/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
+++ b/src/Components/ClustersListTable/ClustersListTable.spec.ct.js
@@ -280,11 +280,10 @@ describe('clusters list table', () => {
     it('can change page limit', () => {
       // FIXME: best way to make the loop
       cy.wrap(PAGINATION_VALUES).each((el) => {
-        changePagination(el).then(
-          () => expect(window.location.search).to.contain(`limit=${el}`)
-          // TODO should check below be nested here as well?
-        );
-        checkRowCounts(Math.min(el, data.length));
+        changePagination(el).then(() => {
+          expect(window.location.search).to.contain(`limit=${el}`);
+          checkRowCounts(Math.min(el, data.length));
+        });
       });
     });
     it('can iterate over pages', () => {

--- a/src/Components/RecsListTable/RecsListTable.spec.ct.js
+++ b/src/Components/RecsListTable/RecsListTable.spec.ct.js
@@ -411,10 +411,10 @@ describe('successful non-empty recommendations list table', () => {
     it('can change page limit', () => {
       // FIXME: best way to make the loop
       cy.wrap(PAGINATION_VALUES).each((el) => {
-        changePagination(el).then(() =>
-          expect(window.location.search).to.contain(`limit=${el}`)
-        );
-        checkRowCounts(Math.min(el, filterData().length));
+        changePagination(el).then(() => {
+          expect(window.location.search).to.contain(`limit=${el}`);
+          checkRowCounts(Math.min(el, filterData().length));
+        });
       });
     });
     it('can iterate over pages', () => {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-8306.

I can't say for sure, but my gut says nesting all the checks within the `then` callback will let us prevent the tests from being flaky. I can't test it anyhow, but if we don't see the issue again in the future, this thing must probably have fixed that.