### PR TITLE
feat(Single recommendation page): add Impacted column

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -35,6 +35,7 @@
   "impact": "Impact",
   "impactDescription": "The impact of the problem would be {level} if it occurred.",
   "impactLevel": "{level} impact",
+  "impacted": "Impacted",
   "important": "Important",
   "insightsHeader": "Advisor",
   "justificationNote": "Justification note",

--- a/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
@@ -7,7 +7,8 @@
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
           "cluster_version": "3.0.3"
-        }
+        },
+        "impacted": "2022-06-13T22:00:00.000Z"
       },
       {
         "cluster": "bcbd9c24-bf3f-4141-9a6c-019f5404164e",
@@ -15,7 +16,8 @@
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
           "cluster_version": "4.17.9"
-        }
+        },
+        "impacted": "2022-06-26T22:00:00.000Z"
       },
       {
         "cluster": "685de527-ad9e-426c-a83f-07d797dd28e8",
@@ -23,7 +25,8 @@
         "last_checked_at": "2022-05-22T08:32:37.690Z",
         "meta": {
           "cluster_version": ""
-        }
+        },
+        "impacted": "2022-06-22T22:00:00.000Z"
       },
       {
         "cluster": "4bc920df-7935-4882-a946-e1e735439620",
@@ -31,7 +34,8 @@
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
           "cluster_version": "3.3.5"
-        }
+        },
+        "impacted": "2022-06-11T22:00:00.000Z"
       },
       {
         "cluster": "41c30565-b4c9-49f2-a4ce-3277ad22b258",
@@ -39,7 +43,8 @@
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
           "cluster_version": "4.17.9"
-        }
+        },
+        "impacted": "2022-06-11T22:00:00.000Z"
       },
       {
         "cluster": "6810f59e-c37c-420a-ae52-c23ccaccffc9",
@@ -47,7 +52,8 @@
         "last_checked_at": "2021-04-02T08:32:37.690Z",
         "meta": {
           "cluster_version": "4.11.16"
-        }
+        },
+        "impacted": "2022-06-09T22:00:00.000Z"
       },
       {
         "cluster": "5d5892d3-1f74-4ccf-22af-548dfc9767bb",
@@ -55,7 +61,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.8.2"
-        }
+        },
+        "impacted": "2022-06-28T22:00:00.000Z"
       },
       {
         "cluster": "444cf4e5-a983-4894-9852-cb8b441b7006",
@@ -63,7 +70,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": ""
-        }
+        },
+        "impacted": "2022-06-28T22:00:00.000Z"
       },
       {
         "cluster": "00d404e4-9e83-46ee-9ddd-83c06fa65d67",
@@ -71,7 +79,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.9.5"
-        }
+        },
+        "impacted": "2022-06-01T22:00:00.000Z"
       },
       {
         "cluster": "e73ee8b2-f60f-4bb0-abc7-be3093debfe7",
@@ -79,7 +88,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.18.12"
-        }
+        },
+        "impacted": ""
       },
       {
         "cluster": "f7331e9a-2f59-484d-af52-338d56165df5",
@@ -87,7 +97,8 @@
         "last_checked_at": "2020-11-07T08:32:37.690Z",
         "meta": {
           "cluster_version": "4.18.12"
-        }
+        },
+        "impacted": ""
       },
       {
         "cluster": "56f646b2-cf9f-46b2-9553-0e399465b966",
@@ -95,7 +106,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.18.12"
-        }
+        },
+        "impacted": "2022-06-02T22:00:00.000Z"
       },
       {
         "cluster": "e508506a-6cac-4925-9582-fdc0338e1020",
@@ -103,7 +115,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.6.13"
-        }
+        },
+        "impacted": "2022-06-16T22:00:00.000Z"
       },
       {
         "cluster": "bb7c5181-5464-4979-90de-135e38c8794a",
@@ -111,7 +124,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.5.0"
-        }
+        },
+        "impacted": "2022-06-28T22:00:00.000Z"
       },
       {
         "cluster": "6367317a-5ffe-472c-a9dc-70d8a67485b4",
@@ -119,7 +133,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.12.8"
-        }
+        },
+        "impacted": "2022-06-21T22:00:00.000Z"
       },
       {
         "cluster": "a7fc5b1a-d3f3-4103-91d3-f1cf560a1910",
@@ -127,7 +142,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.1.7"
-        }
+        },
+        "impacted": "2022-06-16T22:00:00.000Z"
       },
       {
         "cluster": "40dbef1f-0382-4342-8e4e-c2bf299928c5",
@@ -135,7 +151,8 @@
         "last_checked_at": "2021-07-16T12:00:00Z",
         "meta": {
           "cluster_version": "4.9.3"
-        }
+        },
+        "impacted": "2022-06-30T22:00:00.000Z"
       },
       {
         "cluster": "96c55abf-db62-4e99-b01a-9331a757097f",
@@ -143,7 +160,8 @@
         "last_checked_at": "2021-01-11T16:00:00Z",
         "meta": {
           "cluster_version": ""
-        }
+        },
+        "impacted": "2022-06-05T22:00:00.000Z"
       },
       {
         "cluster": "dd2ef343-9131-46f5-8962-290fdfdf2199",
@@ -151,7 +169,8 @@
         "last_checked_at": "2021-10-17T15:00:00Z",
         "meta": {
           "cluster_version": "4.1.18"
-        }
+        },
+        "impacted": "2022-06-11T22:00:00.000Z"
       },
       {
         "cluster": "90f9a6ea-f79a-4d8d-a889-f0fb151aca5e",
@@ -159,7 +178,8 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "3.13.17"
-        }
+        },
+        "impacted": "2022-06-09T22:00:00.000Z"
       },
       {
         "cluster": "ff41a4ee-aa2c-43a2-ac65-d5956252416d",
@@ -167,7 +187,8 @@
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
           "cluster_version": "4.14.14"
-        }
+        },
+        "impacted": "2022-06-17T22:00:00.000Z"
       },
       {
         "cluster": "020cc0a1-6f1a-45fa-9780-3f4e74590902",
@@ -175,7 +196,8 @@
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
           "cluster_version": "3.7.15"
-        }
+        },
+        "impacted": "2022-06-30T22:00:00.000Z"
       },
       {
         "cluster": "75400997-78fe-404e-a900-1c630bc3501d",
@@ -183,7 +205,8 @@
         "last_checked_at": "2020-02-22T08:32:37.690Z",
         "meta": {
           "cluster_version": "4.9.14"
-        }
+        },
+        "impacted": "2022-06-16T22:00:00.000Z"
       }
     ],
     "disabled": [

--- a/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json
@@ -88,8 +88,7 @@
         "last_checked_at": "2021-04-08T20:35:32.798Z",
         "meta": {
           "cluster_version": "4.18.12"
-        },
-        "impacted": ""
+        }
       },
       {
         "cluster": "f7331e9a-2f59-484d-af52-338d56165df5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5129,6 +5129,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -5144,7 +5146,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -31711,15 +31715,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -31731,7 +31734,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -259,18 +259,23 @@ export const RECS_LIST_COLUMNS_KEYS = [
 export const AFFECTED_CLUSTERS_NAME_CELL = 1;
 export const AFFECTED_CLUSTERS_VERSION_CELL = 2;
 export const AFFECTED_CLUSTERS_LAST_SEEN_CELL = 3;
+export const AFFECTED_CLUSTERS_IMPACTED_CELL = 4;
 export const AFFECTED_CLUSTERS_COLUMNS = [
   {
     title: intl.formatMessage(messages.name),
-    transforms: [sortable, cellWidth(70)],
+    transforms: [sortable, cellWidth(60)],
   },
   {
     title: intl.formatMessage(messages.version),
-    transforms: [sortable, cellWidth(15)],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.lastSeen),
-    transforms: [sortable, cellWidth(15)],
+    transforms: [sortable],
+  },
+  {
+    title: intl.formatMessage(messages.impacted),
+    transforms: [sortable],
   },
 ];
 // TODO: remove since unused

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -21,6 +21,7 @@ import {
 } from '../MessageState/EmptyStates';
 import {
   AFFECTED_CLUSTERS_COLUMNS,
+  AFFECTED_CLUSTERS_IMPACTED_CELL,
   AFFECTED_CLUSTERS_LAST_SEEN_CELL,
   AFFECTED_CLUSTERS_NAME_CELL,
   AFFECTED_CLUSTERS_VERSION_CELL,
@@ -148,6 +149,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
           r.cluster_name || r.cluster,
           r.meta.cluster_version,
           r.last_checked_at,
+          r.impacted,
         ],
       };
     });
@@ -182,6 +184,10 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
             fst = new Date(a.cells[AFFECTED_CLUSTERS_LAST_SEEN_CELL] || 0);
             snd = new Date(b.cells[AFFECTED_CLUSTERS_LAST_SEEN_CELL] || 0);
             return fst > snd ? d : snd > fst ? -d : 0;
+          case AFFECTED_CLUSTERS_IMPACTED_CELL:
+            fst = new Date(a.cells[AFFECTED_CLUSTERS_IMPACTED_CELL] || 0);
+            snd = new Date(b.cells[AFFECTED_CLUSTERS_IMPACTED_CELL] || 0);
+            return fst > snd ? d : snd > fst ? -d : 0;
         }
       });
   };
@@ -214,6 +220,27 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
                 content={
                   <span>
                     {intl.formatMessage(messages.lastSeen) + ': '}
+                    {intl.formatMessage(messages.nA)}
+                  </span>
+                }
+              >
+                <span>{intl.formatMessage(messages.nA)}</span>
+              </Tooltip>
+            )}
+          </span>,
+          <span key={r.id}>
+            {r.cells[AFFECTED_CLUSTERS_IMPACTED_CELL] ? (
+              <DateFormat
+                extraTitle={`${intl.formatMessage(messages.impacted)}: `}
+                date={r.cells[AFFECTED_CLUSTERS_IMPACTED_CELL]}
+                variant="relative"
+              />
+            ) : (
+              <Tooltip
+                key={r.id}
+                content={
+                  <span>
+                    {intl.formatMessage(messages.impacted) + ': '}
                     {intl.formatMessage(messages.nA)}
                   </span>
                 }

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -45,6 +45,7 @@ import {
   VERSION_COMBINATIONS,
   filter,
   applyFilters,
+  removeAllChips,
 } from '../../../cypress/utils/filters';
 
 // selectors
@@ -113,13 +114,13 @@ describe('test data', () => {
   it(`has at least one cluster without a version`, () => {
     expect(filterData({ version: [''] })).to.have.length.gte(1);
   });
-  it('has at least three enabled clusters with the same impacted date', () => {
+  it('has at least one enabled cluster with missing impacted date', () => {
     expect(
-      values.filter((v) => v.impacted === '2022-06-28T22:00:00.000Z')
-    ).to.have.length(3);
+      values.filter((v) => !Object.hasOwn(v, 'impacted')).length
+    ).to.be.gte(1);
   });
-  it('has at least one enabled cluster with unknown impacted date', () => {
-    expect(values.filter((v) => v.impacted === '').length).to.be.gte(1);
+  it('has at least one enabled cluster with empty impacted date', () => {
+    expect(values.filter((v) => v['impacted'] === '').length).to.be.gte(1);
   });
 });
 
@@ -458,7 +459,7 @@ describe('non-empty successful affected clusters table', () => {
             if (it['last_checked_at'] === '') {
               it['last_checked_at'] = '1970-01-01T01:00:00.001Z';
             }
-            if (it['impacted'] === '') {
+            if (it['impacted'] === undefined || it['impacted'] === '') {
               it['impacted'] = '1970-01-01T01:00:00.001Z';
             }
             if (it.meta.cluster_version === '') {
@@ -654,6 +655,14 @@ describe('non-empty successful affected clusters table', () => {
       cy.wait('@disableFeedbackRequest');
       // TODO check page is reloaded afterwards
     });
+  });
+
+  it('missing impacted date shown as N/A', () => {
+    filterApply({ name: 'e73ee8b2-f60f-4bb0-abc7-be3093debfe7' });
+    cy.get('[data-label="Impacted"]').should('contain', 'N/A');
+    removeAllChips();
+    filterApply({ name: 'custom cluster name 2' });
+    cy.get('[data-label="Impacted"]').should('contain', 'N/A');
   });
 });
 

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -635,10 +635,12 @@ describe('non-empty successful affected clusters table', () => {
   });
 
   it('missing impacted date shown as N/A', () => {
-    filterApply({ name: 'e73ee8b2-f60f-4bb0-abc7-be3093debfe7' });
+    filterApply({
+      name: values.filter((v) => !Object.hasOwn(v, 'impacted'))[0].name,
+    });
     cy.get('[data-label="Impacted"]').should('contain', 'N/A');
     removeAllChips();
-    filterApply({ name: 'custom cluster name 2' });
+    filterApply({ name: values.filter((v) => v['impacted'] === '')[0].name });
     cy.get('[data-label="Impacted"]').should('contain', 'N/A');
   });
 });

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -113,6 +113,14 @@ describe('test data', () => {
   it(`has at least one cluster without a version`, () => {
     expect(filterData({ version: [''] })).to.have.length.gte(1);
   });
+  it('has at least three enabled clusters with the same impacted date', () => {
+    expect(
+      values.filter((v) => v.impacted === '2022-06-28T22:00:00.000Z')
+    ).to.have.length(3);
+  });
+  it('has at least one enabled cluster with unknown impacted date', () => {
+    expect(values.filter((v) => v.impacted === '').length).to.be.gte(1);
+  });
 });
 
 // TODO: when checking empty state, also check toolbar available and not disabled
@@ -425,7 +433,7 @@ describe('non-empty successful affected clusters table', () => {
 
   describe('sorting', () => {
     _.zip(
-      ['name', 'meta.cluster_version', 'last_checked_at'],
+      ['name', 'meta.cluster_version', 'last_checked_at', 'impacted'],
       TABLE_HEADERS
     ).forEach(([category, label]) => {
       SORTING_ORDERS.forEach((order) => {
@@ -449,6 +457,9 @@ describe('non-empty successful affected clusters table', () => {
           sortedClusters.forEach((it) => {
             if (it['last_checked_at'] === '') {
               it['last_checked_at'] = '1970-01-01T01:00:00.001Z';
+            }
+            if (it['impacted'] === '') {
+              it['impacted'] = '1970-01-01T01:00:00.001Z';
             }
             if (it.meta.cluster_version === '') {
               it.meta.cluster_version = '0.0.0';

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.spec.ct.js
@@ -637,7 +637,7 @@ describe('non-empty successful affected clusters table', () => {
         .find(ROW)
         .first()
         .find('td')
-        .eq(4)
+        .eq(AFFECTED_CLUSTERS_COLUMNS.length + 1)
         .click()
         .contains('Disable')
         .click();

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -609,4 +609,8 @@ export default defineMessages({
     id: 'notAvailable',
     defaultMessage: 'Not available',
   },
+  impacted: {
+    id: 'impacted',
+    defaultMessage: 'Impacted',
+  },
 });


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/CCXDEV-7462.

The "Impacted" column displays the date when the recommendation first hit the particular cluster. The column is sortable, no filter is required.

![Screenshot 2022-07-04 at 14-12-44 Reduced ability to recover from faults when SDI backup is not enabled - Recommendations - OCP Advisor Red Hat Insights console redhat com](https://user-images.githubusercontent.com/31385370/177152572-8bc376c2-242e-4f64-a28c-983313553c51.png)
