### PR TITLE
refactor: remove trailing slashes in endpoint paths

### DIFF
--- a/src/Components/Recommendation/Recommendation.js
+++ b/src/Components/Recommendation/Recommendation.js
@@ -125,7 +125,7 @@ const Recommendation = ({ rule, ack, clusters, match }) => {
 
   const enableRule = async (rule) => {
     try {
-      await Delete(`${BASE_URL}/v2/ack/${rule.data.content.rule_id}/`);
+      await Delete(`${BASE_URL}/v2/ack/${rule.data.content.rule_id}`);
       notify({
         variant: 'success',
         timeout: true,

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -498,7 +498,7 @@ const RecsListTable = ({ query }) => {
         setDisableRuleOpen(true);
       } else {
         try {
-          await Delete(`${BASE_URL}/v2/ack/${rule.rule_id}/`);
+          await Delete(`${BASE_URL}/v2/ack/${rule.rule_id}`);
           notify({
             variant: 'success',
             timeout: true,


### PR DESCRIPTION
This removes trailing slashes from endpoints. Before, it was causing 301 responses.