### PR TITLE
OUIA safe tags for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can use the mocked version of Insights Results Aggregator (or Smart Proxy) A
 [Cypress](https://docs.cypress.io/guides/component-testing) and [Jest](https://jestjs.io/) are used as the testing frameworks.
 
 - Run `npm run test` to execute unit-test suite (Jest + Cypress component testing).
-- Run `npx cypress open-ct` to open Cypress in the component tesing mode.
+- Run `npx cypress open --component` to open Cypress in the component tesing mode.
 
 ## Deploying
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "webpack serve --config config/dev.webpack.config.js",
     "start:beta": "BETA=true npm start",
     "start:beta:mock": "BETA=true MOCK=true npm start",
-    "test:ct": "cypress run-ct",
+    "test:ct": "cypress run --component",
     "test:jest": "jest --verbose --passWithNoTests",
     "test": "npm run test:ct && npm run test:jest",
     "coverage": "bash coverage.sh",

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -372,6 +372,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
       <Table
         aria-label="Table of affected clusters"
         ouiaId="clusters"
+        ouiaSafe={!loadingState}
         variant="compact"
         cells={AFFECTED_CLUSTERS_COLUMNS}
         rows={

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -67,7 +67,9 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   const page = filters.offset / filters.limit + 1;
   const allSelected =
     filteredRows.length !== 0 && selected.length === filteredRows.length;
-  const loadingState = isUninitialized || isFetching;
+  // helps to distinguish the state when the API data received but not yet filtered
+  const [rowsFiltered, setRowsFiltered] = useState(false);
+  const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError;
   const successState = isSuccess;
   const noInput = successState && rows.length === 0;
@@ -121,20 +123,24 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   };
 
   const onSort = (_e, index, direction) => {
+    setRowsFiltered(false);
     updateFilters({ ...filters, sortIndex: index, sortDirection: direction });
   };
 
   const onSetPage = (_e, pageNumber) => {
+    setRowsFiltered(false);
     const newOffset = pageNumber * filters.limit - filters.limit;
     updateFilters({ ...filters, offset: newOffset });
   };
 
   const onSetPerPage = (_e, perPage) => {
+    setRowsFiltered(false);
     updateFilters({ ...filters, limit: perPage });
   };
 
   // constructs array of rows (from the initial data) checking currently applied filters
   const buildFilteredRows = (allRows, filters) => {
+    setRowsFiltered(false);
     const rows = allRows.map((r) => {
       if (r.meta.cluster_version !== '' && !valid(r.meta.cluster_version)) {
         console.error(
@@ -272,6 +278,9 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
     const newDisplayedRows = buildDisplayedRows(newFilteredRows);
     setFilteredRows(newFilteredRows);
     setDisplayedRows(newDisplayedRows);
+    if (isSuccess && !rowsFiltered) {
+      setRowsFiltered(true);
+    }
   }, [query, filters]);
 
   const handleModalToggle = (disableRuleModalOpen, host = undefined) => {
@@ -280,7 +289,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   };
 
   return (
-    <div id="affected-list-table">
+    <div id="affected-list-table" data-ouia-safe={!loadingState}>
       {disableRuleModalOpen && (
         <DisableRule
           handleModalToggle={handleModalToggle}

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -278,7 +278,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
     const newDisplayedRows = buildDisplayedRows(newFilteredRows);
     setFilteredRows(newFilteredRows);
     setDisplayedRows(newDisplayedRows);
-    if (isSuccess && !rowsFiltered) {
+    if (isSuccess) {
       setRowsFiltered(true);
     }
   }, [query, filters]);

--- a/src/Components/ClusterRules/ClusterRules.cy.js
+++ b/src/Components/ClusterRules/ClusterRules.cy.js
@@ -391,7 +391,7 @@ describe('cluster rules table testing the first query parameter', () => {
       if (order === 'ascending') {
         cy.get(header).find('button').click();
       } else {
-        cy.get(header).find('button').dblclick();
+        cy.get(header).find('button').click().click();
       }
       let sortedDescriptions = _.map(
         _.orderBy(

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -105,7 +105,7 @@ const ClusterRules = ({ cluster }) => {
 
   useEffect(() => {
     setFilteredRows(buildFilteredRows(reports, filters));
-    if (isSuccess && !rowsFiltered) {
+    if (isSuccess) {
       setRowsFiltered(true);
     }
   }, [data, filters]);

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -68,9 +68,9 @@ const ClusterRules = ({ cluster }) => {
   const [firstRule, setFirstRule] = useState(''); // show a particular rule first
   const results = filteredRows.length;
   const { search } = useLocation();
-  const [rowsUpdating, setRowsUpdating] = useState(true);
+  // helps to distinguish the state when the API data received but not yet filtered
   const [rowsFiltered, setRowsFiltered] = useState(false);
-  const loadingState = isUninitialized || isFetching || rowsUpdating;
+  const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError;
   const successState = isSuccess;
   const noInput = successState && reports.length === 0;
@@ -105,13 +105,15 @@ const ClusterRules = ({ cluster }) => {
 
   useEffect(() => {
     setFilteredRows(buildFilteredRows(reports, filters));
+    if (isSuccess && !rowsFiltered) {
+      setRowsFiltered(true);
+    }
   }, [data, filters]);
 
   useEffect(() => {
     setDisplayedRows(
       buildDisplayedRows(filteredRows, filters.sortIndex, filters.sortDirection)
     );
-    setRowsFiltered(true);
   }, [
     filteredRows,
     filters.limit,
@@ -119,12 +121,6 @@ const ClusterRules = ({ cluster }) => {
     filters.sortIndex,
     filters.sortDirection,
   ]);
-
-  useEffect(() => {
-    if (rowsFiltered) {
-      setRowsUpdating(false);
-    }
-  }, [rowsFiltered]);
 
   const handleOnCollapse = (_e, rowId, isOpen) => {
     if (rowId === undefined) {
@@ -146,6 +142,7 @@ const ClusterRules = ({ cluster }) => {
   };
 
   const buildFilteredRows = (allRows, filters) => {
+    setRowsFiltered(false);
     const expandedRowsSet = new Set(
       displayedRows
         .filter((ruleExpanded) => ruleExpanded?.isOpen)
@@ -269,6 +266,7 @@ const ClusterRules = ({ cluster }) => {
   };
 
   const onSort = (_e, index, direction) => {
+    setRowsFiltered(false);
     setExpandFirst(false);
     setFirstRule('');
     return updateFilters({
@@ -404,7 +402,7 @@ const ClusterRules = ({ cluster }) => {
   };
 
   return (
-    <div id="cluster-recs-list-table">
+    <div id="cluster-recs-list-table" data-ouia-safe={!loadingState}>
       <PrimaryToolbar
         filterConfig={{
           items: filterConfigItems,

--- a/src/Components/ClusterRules/ClusterRules.js
+++ b/src/Components/ClusterRules/ClusterRules.js
@@ -424,6 +424,7 @@ const ClusterRules = ({ cluster }) => {
       <Table
         aria-label={'Cluster recommendations table'}
         ouiaId="recommendations"
+        ouiaSafe={!loadingState}
         onCollapse={handleOnCollapse} // TODO: set undefined when there is an empty state
         rows={
           errorState || loadingState || noMatch || noInput ? (

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -123,6 +123,7 @@ const ClustersListTable = ({
   }, [filters, filterBuilding]);
 
   const buildFilteredRows = (items) => {
+    setRowsFiltered(false);
     const filtered = items.filter((it) => {
       return passFiltersCluster(it, filters);
     });
@@ -295,6 +296,7 @@ const ClustersListTable = ({
   };
 
   const onSort = (_e, index, direction) => {
+    setRowsFiltered(false);
     updateFilters({ ...filters, sortIndex: index, sortDirection: direction });
   };
 
@@ -303,19 +305,23 @@ const ClustersListTable = ({
       {isSuccess && clusters.length === 0 ? (
         <NoRecsForClusters /> // TODO: do not mix this logic in the table component
       ) : (
-        <div id="clusters-list-table">
+        <div id="clusters-list-table" data-ouia-safe={!loadingState}>
           <PrimaryToolbar
             pagination={{
               itemCount: filteredRows.length,
               page,
               perPage: filters.limit,
-              onSetPage: (_event, page) =>
-                updateFilters({
+              onSetPage: (_event, page) => {
+                setRowsFiltered(false);
+                return updateFilters({
                   ...filters,
                   offset: filters.limit * (page - 1),
-                }),
-              onPerPageSelect: (_event, perPage) =>
-                updateFilters({ ...filters, limit: perPage, offset: 0 }),
+                });
+              },
+              onPerPageSelect: (_event, perPage) => {
+                setRowsFiltered(false);
+                return updateFilters({ ...filters, limit: perPage, offset: 0 });
+              },
               isCompact: true,
               ouiaId: 'pager',
             }}

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -331,6 +331,7 @@ const ClustersListTable = ({
           <Table
             aria-label="Table of clusters"
             ouiaId="clusters"
+            ouiaSafe={!loadingState}
             variant={TableVariant.compact}
             cells={CLUSTERS_LIST_COLUMNS}
             rows={

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -88,7 +88,7 @@ const ClustersListTable = ({
 
   useEffect(() => {
     setFilteredRows(buildFilteredRows(clusters));
-    if (isSuccess && !rowsFiltered) {
+    if (isSuccess) {
       setRowsFiltered(true);
     }
   }, [data, filters]);

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -101,7 +101,7 @@ const RecsListTable = ({ query }) => {
     setDisplayedRows(
       buildDisplayedRows(filteredRows, filters.sortIndex, filters.sortDirection)
     );
-    if (isSuccess && !rowsFiltered) {
+    if (isSuccess) {
       setRowsFiltered(true);
     }
   }, [

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -649,7 +649,7 @@ const RecsListTable = ({ query }) => {
         onSort={onSort}
         actionResolver={actionResolver}
         isStickyHeader
-        ouiaSafe={testSafe}
+        ouiaSafe={!loadingState}
         canCollapseAll
       >
         <TableHeader />

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -84,8 +84,6 @@ const RecsListTable = ({ query }) => {
   const [filterBuilding, setFilterBuilding] = useState(true);
   // helps to distinguish the state when the API data received but not yet filtered
   const [rowsFiltered, setRowsFiltered] = useState(false);
-  // helps to distinguish if the component safe to test
-  const testSafe = rowsFiltered && !(isFetching || isUninitialized);
   const updateFilters = (filters) => dispatch(updateRecsListFilters(filters));
   const searchText = filters?.text || '';
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
@@ -577,7 +575,7 @@ const RecsListTable = ({ query }) => {
   };
 
   return (
-    <div id="recs-list-table" data-ouia-safe={testSafe}>
+    <div id="recs-list-table" data-ouia-safe={!loadingState}>
       {disableRuleOpen && (
         <DisableRule
           handleModalToggle={setDisableRuleOpen}


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-24.

Use the `data-ouia-safe` tag and `ouiaSafe` PF component property in each table in Advisor (recs list, clusters list, affected clusters list, cluster reports list). The tag is set to false if there is an animation in a table (= a table is in the loading state); otherwise is true.