### PR TITLE
Recommendation page tests

### DIFF
--- a/src/Components/Modals/ViewHostAcks.js
+++ b/src/Components/Modals/ViewHostAcks.js
@@ -111,6 +111,7 @@ const ViewHostAcks = ({
         unclean && afterFn();
         handleModalToggle(false);
       }}
+      ouiaId="hosts-disabled"
     >
       {!isFetching ? (
         <Table aria-label="host-ack-table" rows={rows} cells={columns}>

--- a/src/Components/Modals/ViewHostsAcks.cy.js
+++ b/src/Components/Modals/ViewHostsAcks.cy.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import _ from 'lodash';
+
+import ViewHostAcks from './ViewHostAcks';
+import { Intl } from '../../Utilities/intlHelper';
+import getStore from '../../Store';
+import clusterDetails from '../../../cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json';
+import { TBODY, ROW } from '../../../cypress/utils/components';
+
+const MODAL = 'hosts-disabled';
+
+const defaultPropsClusterDetails = {
+  data: clusterDetails.data,
+  isFetching: false,
+  isSuccess: true,
+  refetch: undefined,
+};
+
+describe('modal with hosts', () => {
+  beforeEach(() => {
+    mount(
+      <MemoryRouter>
+        <Intl>
+          <Provider store={getStore()}>
+            <ViewHostAcks
+              isModalOpen={true}
+              clusters={{ ...defaultPropsClusterDetails }}
+              recId={'abc|xyz'}
+            />
+          </Provider>
+        </Intl>
+      </MemoryRouter>
+    );
+
+    cy.intercept(
+      'PUT',
+      '/api/insights-results-aggregator/v1/clusters/**/rules/**/error_key/**/enable',
+      {
+        statusCode: 200,
+      }
+    ).as('enableRequest');
+  });
+
+  it('exits', () => {
+    cy.ouiaId(MODAL).should('exist');
+  });
+
+  it('empty justification notes are rendered as None', () => {
+    const justifications = _.map(
+      clusterDetails.data.disabled,
+      (it) => it.justification || 'None'
+    );
+    cy.get(`td[data-label="Justification note"]`)
+      .then(($els) => {
+        return _.map(Cypress.$.makeArray($els), 'innerText');
+      })
+      .should('deep.equal', justifications);
+  });
+
+  it('clusters can be enabled', () => {
+    cy.get('table')
+      .find(TBODY)
+      .find(ROW)
+      .first()
+      .ouiaId('enable')
+      .click()
+      .then(() => {
+        cy.wait('@enableRequest').then((xhr) => {
+          expect(xhr.request.url).to.contain(
+            clusterDetails.data.disabled[0].cluster_id
+          );
+          expect(xhr.request.url).to.contain('abc.report');
+          expect(xhr.request.url).to.contain('xyz');
+        });
+      });
+  });
+});

--- a/src/Components/Recommendation/Recommendation.cy.js
+++ b/src/Components/Recommendation/Recommendation.cy.js
@@ -119,7 +119,7 @@ describe('recommendation page for enabled recommendation with clusters enabled a
     cy.ouiaId('recommendation-disable').should('exist');
   });
 
-  it.only('all clusters can be enabled at once', () => {
+  it('all clusters can be enabled at once', () => {
     cy.ouiaId('hosts-acked')
       .ouiaId('enable')
       .click()
@@ -133,7 +133,7 @@ describe('recommendation page for enabled recommendation with clusters enabled a
       });
   });
 
-  describe.only('disabled clusters modal', () => {
+  describe('disabled clusters modal', () => {
     it('can be displayed', () => {
       cy.ouiaId('hosts-acked').ouiaId('view-clusters').click();
       cy.ouiaId('hosts-disabled').should('exist');

--- a/src/Components/Recommendation/Recommendation.cy.js
+++ b/src/Components/Recommendation/Recommendation.cy.js
@@ -11,6 +11,7 @@ import rule from '../../../cypress/fixtures/api/insights-results-aggregator/v2/r
 import ack from '../../../cypress/fixtures/api/insights-results-aggregator/v2/ack/external.rules.rule|ERROR_KEY.json';
 import clusterDetails from '../../../cypress/fixtures/api/insights-results-aggregator/v2/rule/external.rules.rule|ERROR_KEY/clusters_detail.json';
 import { CATEGORIES } from '../../../cypress/utils/globals';
+import { TBODY, ROW } from '../../../cypress/utils/components';
 
 const defaultPropsRule = {
   isError: false,
@@ -108,6 +109,29 @@ describe('recommendation page for enabled recommendation with clusters enabled a
         cy.get('a').should('have.text', 'Disable recommendation').click();
       });
     cy.ouiaId('recommendation-disable').should('exist');
+  });
+
+  describe.only('disabled clusters modal', () => {
+    it('can be displayed', () => {
+      cy.ouiaId('hosts-acked').ouiaId('view-clusters').click();
+      cy.ouiaId('hosts-disabled').should('exist');
+    });
+    it('has expected clusters', () => {
+      cy.ouiaId('hosts-acked').ouiaId('view-clusters').click();
+      cy.ouiaId('hosts-disabled')
+        .find(TBODY)
+        .find(ROW)
+        .should('have.length', clusterDetails.data.disabled.length);
+      const clusters = _.map(
+        clusterDetails.data.disabled,
+        (it) => it.cluster_name || it.cluster_id
+      );
+      cy.get(`td[data-label="Cluster name"]`)
+        .then(($els) => {
+          return _.map(Cypress.$.makeArray($els), 'innerText');
+        })
+        .should('deep.equal', clusters);
+    });
   });
 });
 

--- a/src/Components/Recommendation/Recommendation.cy.js
+++ b/src/Components/Recommendation/Recommendation.cy.js
@@ -215,7 +215,6 @@ describe('recommendation page for enabled recommendation without disabled cluste
   });
 });
 
-// TODO check disabledRule with ack data undefined. Makes sense?
 describe('recommendation page for disabled recommendation', () => {
   beforeEach(() => {
     mount(


### PR DESCRIPTION
Improve tests for recommendations page

* test modal for disabled hosts
* test page without disabled clusters
* test enabling all clusters from card

Implements [CCXDEV-8415](https://issues.redhat.com/browse/CCXDEV-8415)