### PR TITLE
chore(OCPADVISOR-52): replace impacted label

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -35,7 +35,7 @@
   "impact": "Impact",
   "impactDescription": "The impact of the problem would be {level} if it occurred.",
   "impactLevel": "{level} impact",
-  "impacted": "Impacted",
+  "impacted": "First impacted",
   "important": "Important",
   "insightsHeader": "Advisor",
   "justificationNote": "Justification note",

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -269,7 +269,7 @@ export const AFFECTED_CLUSTERS_IMPACTED_CELL = 4;
 export const AFFECTED_CLUSTERS_COLUMNS = [
   {
     title: intl.formatMessage(messages.name),
-    transforms: [sortable, cellWidth(60)],
+    transforms: [sortable, cellWidth(50)],
   },
   {
     title: intl.formatMessage(messages.version),

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.cy.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.cy.js
@@ -115,9 +115,9 @@ describe('test data', () => {
     expect(filterData({ version: [''] })).to.have.length.gte(1);
   });
   it('has at least one enabled cluster with missing impacted date', () => {
-    expect(
-      values.filter((v) => !Object.hasOwn(v, 'impacted')).length
-    ).to.be.gte(1);
+    expect(values.filter((v) => v['impacted'] === undefined).length).to.be.gte(
+      1
+    );
   });
   it('has at least one enabled cluster with empty impacted date', () => {
     expect(values.filter((v) => v['impacted'] === '').length).to.be.gte(1);
@@ -636,12 +636,12 @@ describe('non-empty successful affected clusters table', () => {
 
   it('missing impacted date shown as Not available', () => {
     filterApply({
-      name: values.filter((v) => !Object.hasOwn(v, 'impacted'))[0].name,
+      name: values.filter((v) => v['impacted'] === undefined)[0].name,
     });
-    cy.get('[data-label="Impacted"]').should('contain', 'Not available');
+    cy.get('[data-label="First impacted"]').should('contain', 'Not available');
     removeAllChips();
     filterApply({ name: values.filter((v) => v['impacted'] === '')[0].name });
-    cy.get('[data-label="Impacted"]').should('contain', 'Not available');
+    cy.get('[data-label="First impacted"]').should('contain', 'Not available');
   });
 });
 

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -607,6 +607,6 @@ export default defineMessages({
   },
   impacted: {
     id: 'impacted',
-    defaultMessage: 'Impacted',
+    defaultMessage: 'First impacted',
   },
 });


### PR DESCRIPTION
The title of the "Impacted" column wasn't describing well what we're showing there. This PR replaces it with "First impacted".