### PR TITLE
fix(redux):Fixing bug in stage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.23",
         "@redhat-cloud-services/rule-components": "^3.2.6",
-        "@reduxjs/toolkit": "^1.8.6",
+        "@reduxjs/toolkit": "^1.9.0",
         "axios": "^0.27.2",
         "babel-plugin-formatjs": "^10.3.29",
         "classnames": "^2.3.1",
@@ -4081,14 +4081,14 @@
       "integrity": "sha512-K2EgxRwszLzvch2nh72wNm8HOlcp6ljTNzUT3bcSfHRNN0poUHtslfcaJTE9EHbWglIH4rwKEhHkHQJGGtcexw=="
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.6.tgz",
-      "integrity": "sha512-4Ia/Loc6WLmdSOzi7k5ff7dLK8CgG2b8aqpLsCAJhazAzGdp//YBUSaj0ceW6a3kDBDNRrq5CRwyCS0wBiL1ig==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.0.tgz",
+      "integrity": "sha512-ak11IrjYcUXRqlhNPwnz6AcvA2ynJTu8PzDbbqQw4a3xR4KZtgiqbNblQD+10CRbfK4+5C79SOyxnT9dhBqFnA==",
       "dependencies": {
-        "immer": "^9.0.7",
-        "redux": "^4.1.2",
-        "redux-thunk": "^2.4.1",
-        "reselect": "^4.1.5"
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
@@ -11478,9 +11478,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
-      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==",
+      "version": "9.0.16",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
+      "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -20698,9 +20698,9 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "peerDependencies": {
         "redux": "^4"
       }
@@ -21220,9 +21220,9 @@
       "dev": true
     },
     "node_modules/reselect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
-      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -27880,14 +27880,14 @@
       "integrity": "sha512-K2EgxRwszLzvch2nh72wNm8HOlcp6ljTNzUT3bcSfHRNN0poUHtslfcaJTE9EHbWglIH4rwKEhHkHQJGGtcexw=="
     },
     "@reduxjs/toolkit": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.6.tgz",
-      "integrity": "sha512-4Ia/Loc6WLmdSOzi7k5ff7dLK8CgG2b8aqpLsCAJhazAzGdp//YBUSaj0ceW6a3kDBDNRrq5CRwyCS0wBiL1ig==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.0.tgz",
+      "integrity": "sha512-ak11IrjYcUXRqlhNPwnz6AcvA2ynJTu8PzDbbqQw4a3xR4KZtgiqbNblQD+10CRbfK4+5C79SOyxnT9dhBqFnA==",
       "requires": {
-        "immer": "^9.0.7",
-        "redux": "^4.1.2",
-        "redux-thunk": "^2.4.1",
-        "reselect": "^4.1.5"
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
       }
     },
     "@scalprum/core": {
@@ -33653,9 +33653,9 @@
       "dev": true
     },
     "immer": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
-      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
+      "version": "9.0.16",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
+      "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ=="
     },
     "immutable": {
       "version": "4.1.0",
@@ -40191,9 +40191,9 @@
       "requires": {}
     },
     "redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "requires": {}
     },
     "regenerate": {
@@ -40574,9 +40574,9 @@
       "dev": true
     },
     "reselect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
-      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "resolve": {
       "version": "1.20.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.23",
     "@redhat-cloud-services/rule-components": "^3.2.6",
-    "@reduxjs/toolkit": "^1.8.6",
+    "@reduxjs/toolkit": "^1.9.0",
     "axios": "^0.27.2",
     "babel-plugin-formatjs": "^10.3.29",
     "classnames": "^2.3.1",


### PR DESCRIPTION
Updating redux toolkit to fix the bug in stage

The bug - for some reason when you switch between recommendations and clusters page the table stop loading and get stuck in the "isFetching" 
![image](https://user-images.githubusercontent.com/62722417/202705025-c9896d89-3fb5-4148-8854-4421f2b8fe77.png)


to reproduce, open the https://console.stage.redhat.com/openshift/insights/advisor/recommendations
Go to Clusters table then back to Recommendations table


How to test this PR
0. You need both Insights Chrome and OCP Advisor locally.
1. Add route in Insights Chrome a to the wepback.config.js
`...proxy({
        env: 'stage-beta',
        port: 1337,
        appUrl: [/^\/*$/, /^\/beta\/*$/],
        useProxy: true,
        publicPath,
        proxyVerbose: true,
        isChrome: true,
        routes: {
          '/apps/ocp-advisor': {
            host: 'https://localhost:8004',
          },
        },
      }),`

2. run insights chrome with "npm run dev"
3. run this command in OCP Advisor
"BETA=true npx webpack serve --config config/dev.webpack.config.js --port=8004"
4. Visit the https://stage.foo.redhat.com:1337/beta/openshift/insights/advisor/recommendations then open Clusters table. After that go back to the Recommendations table
