### PR TITLE
refactor: Replace Main with section tag

### DIFF
--- a/src/Components/Cluster/Cluster.js
+++ b/src/Components/Cluster/Cluster.js
@@ -7,7 +7,6 @@ import PageHeader from '@redhat-cloud-services/frontend-components/PageHeader';
 import ClusterHeader from '../ClusterHeader';
 import ClusterRules from '../ClusterRules/ClusterRules';
 import Breadcrumbs from '../Breadcrumbs';
-import Main from '@redhat-cloud-services/frontend-components/Main';
 
 export const Cluster = ({ cluster, match }) => {
   // TODO: make breadcrumbs take display name from GET /cluster/id/info
@@ -22,9 +21,9 @@ export const Cluster = ({ cluster, match }) => {
         />
         <ClusterHeader />
       </PageHeader>
-      <Main>
+      <section className="pf-l-page__main-section pf-c-page__main-section">
         <ClusterRules cluster={cluster} />
-      </Main>
+      </section>
     </React.Fragment>
   );
 };

--- a/src/Components/ClustersList/index.js
+++ b/src/Components/ClustersList/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 
 import PageHeader from '@redhat-cloud-services/frontend-components/PageHeader';
-import Main from '@redhat-cloud-services/frontend-components/Main';
 
 import messages from '../../Messages';
 import ClustersListTable from '../ClustersListTable';
@@ -25,9 +24,9 @@ const ClustersList = () => {
             .toLowerCase()}`}
         </Title>
       </PageHeader>
-      <Main>
+      <section className="pf-l-page__main-section pf-c-page__main-section">
         <ClustersListTable />
-      </Main>
+      </section>
     </React.Fragment>
   );
 };

--- a/src/Components/Recommendation/Recommendation.js
+++ b/src/Components/Recommendation/Recommendation.js
@@ -15,7 +15,6 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import {
   Label,
@@ -174,18 +173,18 @@ const Recommendation = ({ rule, ack, clusters, match }) => {
         <Breadcrumbs current={content?.description || recId} />
       </PageHeader>
       {(isUninitialized || isLoading || isFetching) && (
-        <Main>
+        <section className="pf-l-page__main-section pf-c-page__main-section pf-m-light pf-u-pt-sm">
           <Loading />
-        </Main>
+        </section>
       )}
       {isError && (
-        <Main>
+        <section className="pf-l-page__main-section pf-c-page__main-section pf-m-light pf-u-pt-sm">
           <ErrorState />
-        </Main>
+        </section>
       )}
       {!(isUninitialized || isLoading || isFetching) && isSuccess && (
         <React.Fragment>
-          <Main className="pf-m-light pf-u-pt-sm">
+          <section className="pf-l-page__main-section pf-c-page__main-section pf-m-light pf-u-pt-sm">
             <RuleDetails
               messages={formatMessages(
                 intl,
@@ -298,8 +297,8 @@ const Recommendation = ({ rule, ack, clusters, match }) => {
                 </FlexItem>
               </Flex>
             </RuleDetails>
-          </Main>
-          <Main>
+          </section>
+          <section className="pf-l-page__main-section pf-c-page__main-section">
             <React.Fragment>
               {(content?.hosts_acked_count ||
                 ackedClusters?.length > 0 ||
@@ -434,7 +433,7 @@ const Recommendation = ({ rule, ack, clusters, match }) => {
                 />
               )}
             </React.Fragment>
-          </Main>
+          </section>
         </React.Fragment>
       )}
     </React.Fragment>

--- a/src/Components/RecsList/index.js
+++ b/src/Components/RecsList/index.js
@@ -1,7 +1,6 @@
 import React, { lazy, Suspense } from 'react';
 import { useIntl } from 'react-intl';
 
-import Main from '@redhat-cloud-services/frontend-components/Main';
 import PageHeader from '@redhat-cloud-services/frontend-components/PageHeader';
 
 import Loading from '../Loading/Loading';
@@ -29,11 +28,11 @@ const RecsList = () => {
             .toLowerCase()}`}
         </Title>
       </PageHeader>
-      <Main>
+      <section className="pf-l-page__main-section pf-c-page__main-section">
         <Suspense fallback={<Loading />}>
           <RecsListTable />
         </Suspense>
-      </Main>
+      </section>
     </React.Fragment>
   );
 };

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -112,7 +112,7 @@ const RecsListTable = ({ query }) => {
   ]);
 
   useEffect(() => {
-    let filteredRows = buildFilteredRows(recs, filters);
+    const filteredRows = buildFilteredRows(recs, filters);
     if (filteredRows.length && filteredRows.length <= filters.offset) {
       updateFilters({
         ...filters,
@@ -237,7 +237,7 @@ const RecsListTable = ({ query }) => {
           cells: [
             {
               title: (
-                <section className="pf-m-light pf-l-page__main-section pf-c-page__main-section">
+                <section className="pf-l-page__main-section pf-c-page__main-section pf-m-light">
                   <Stack hasGutter>
                     <RuleDetails
                       messages={formatMessages(
@@ -265,8 +265,8 @@ const RecsListTable = ({ query }) => {
 */
   const buildDisplayedRows = (rows, index, direction) => {
     const sortingRows = [...rows].sort((firstItem, secondItem) => {
-      let fst = firstItem[0].rule,
-        snd = secondItem[0].rule;
+      let fst = firstItem[0].rule;
+      let snd = secondItem[0].rule;
       const d = direction === SortByDirection.asc ? 1 : -1;
       switch (index) {
         case RECS_LIST_NAME_CELL:
@@ -515,7 +515,7 @@ const RecsListTable = ({ query }) => {
       setDisplayedRows(
         displayedRows.map((row) => ({
           ...row,
-          isOpen: isOpen,
+          isOpen,
         }))
       );
     } else {


### PR DESCRIPTION
This removes the usage of Main component that was connecting to the global chroming store and was prone to errors. The replacement is the section tag with custom PF class names.