### PR TITLE
feat(Recs list): Risk of change details section

### DIFF
--- a/src/Components/RecsListTable/RecsListTable.cy.js
+++ b/src/Components/RecsListTable/RecsListTable.cy.js
@@ -255,12 +255,22 @@ describe('data', () => {
       _.filter(filterData(), (it) => it.impacted_clusters_count > 1)
     ).to.have.length.gte(1);
   });
+  it('at least one recommendation in default list has resolution risk set to non 0 value', () => {
+    expect(
+      filterData().filter(
+        ({ resolution_risk, description }) =>
+          resolution_risk >= 1 &&
+          description.includes('1Lorem ipsum dolor sit amet')
+      ).length
+    ).to.gte(1);
+  });
   it('at least one recommendation in default list has resolution risk set to 0', () => {
     expect(
-      filterData({
-        name: 'Super atomic nuclear cluster on the brink of the world destruction',
-      })[0].resolution_risk
-    ).to.eq(0);
+      filterData().filter(
+        ({ resolution_risk, description }) =>
+          resolution_risk === 0 && description.includes('Super atomic nuclear')
+      ).length
+    ).to.gte(1);
   });
 });
 
@@ -667,6 +677,34 @@ describe('successful non-empty recommendations list table', () => {
       )
         .find('[data-label="Risk of change"]')
         .should('have.text', 'Not available');
+    });
+
+    it('absent resolution risk is not shown in expanded details', () => {
+      cy.getRowByName(
+        'Super atomic nuclear cluster on the brink of the world destruction'
+      )
+        .find('.pf-c-table__toggle button')
+        .click();
+      cy.get(EXPANDABLES)
+        .eq(0)
+        .find('.pf-m-spacer-sm')
+        .contains('Risk of change')
+        .should('not.exist');
+    });
+
+    it('present resolution risk is shown in expanded details', () => {
+      cy.getRowByName('1Lorem ipsum dolor sit amet')
+        .find('.pf-c-table__toggle button')
+        .click();
+      cy.get(EXPANDABLES)
+        .eq(0)
+        .find('.pf-m-spacer-sm')
+        .contains('Risk of change')
+        .should('exist');
+      cy.get(EXPANDABLES)
+        .eq(0)
+        .find('.ins-c-rule-details__risk-of-ch-label')
+        .should('have.text', 'High');
     });
   });
 

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -35,6 +35,7 @@ import {
   TOTAL_RISK_LABEL_LOWER,
   RISK_OF_CHANGE_LABEL,
   RECS_LIST_RISK_OF_CHANGE_CELL,
+  RISK_OF_CHANGE_DESC,
 } from '../../AppConstants';
 import messages from '../../Messages';
 import {
@@ -263,6 +264,13 @@ const RecsListTable = ({ query }) => {
                       isDetailsPage={false}
                       showViewAffected
                       linkComponent={Link}
+                      {...(inRange(value?.resolution_risk, 1, 5) // resolution risk can be 0 (not defined for particular rule)
+                        ? {
+                            resolutionRisk: value?.resolution_risk,
+                            resolutionRiskDesc:
+                              RISK_OF_CHANGE_DESC[value?.resolution_risk],
+                          }
+                        : {})}
                     />
                   </Stack>
                 </section>


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-66.

This adds a new section to expanded rule content on the recommendations list table. The section shows information about the risk of change for the given rule.

## How to test

Navigate to /openshift/insights/advisor/recommendations. Check that for the rows that have risk of change value, the expanded information contains the risk of change section. For the rules that do not have (currently, all external rules have risk of change, but the tests cover this case), the section must be empty in the expanded content.

## Screenshots

![image](https://user-images.githubusercontent.com/31385370/213439603-7f178e59-9f83-4407-9188-841e6ae43c14.png)
