### PR TITLE
Enable UI IQE tests as part of pr_checks

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -18,20 +18,33 @@ COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-fronten
 # --------------------------------------------
 IQE_PLUGINS="ccx"
 IQE_MARKER_EXPRESSION="ui"
-IQE_FILTER_EXPRESSION=""
+IQE_FILTER_EXPRESSION="test_page"
+
+export DEPLOY_FRONTENDS="true"
+export IQE_ENV="ephemeral"
+export IQE_SELENIUM="true"
+export IQE_CJI_TIMEOUT="30m"
+
+REF_ENV="insights-production"
+#COMPONENTS_W_RESOURCES=""
+COMPONENT_NAME="ocp-advisor
+#COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
+
 
 set -exv
 # source is preferred to | bash -s in this case to avoid a subshell
 source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
-BUILD_RESULTS=$?
 
-# Stubbed out for now
-mkdir -p $WORKSPACE/artifacts
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
-<testsuite tests="1">
-    <testcase classname="dummy" name="dummytest"/>
-</testsuite>
-EOF
+# Install bonfire repo/initialize
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+# shellcheck source=/dev/null
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
-# teardown_docker
-exit $BUILD_RESULTS
+# Run smoke tests
+# shellcheck source=/dev/null
+source "${CICD_ROOT}/deploy_ephemeral_env.sh"
+# shellcheck source=/dev/null
+#export COMPONENT_NAME="compliance"
+source "${CICD_ROOT}/cji_smoke_test.sh"
+# shellcheck source=/dev/null
+source "${CICD_ROOT}/post_test_results.sh"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,7 +27,7 @@ export IQE_CJI_TIMEOUT="30m"
 
 REF_ENV="insights-production"
 #COMPONENTS_W_RESOURCES=""
-COMPONENT_NAME="ocp-advisor
+export COMPONENT_NAME="ocp-advisor
 #COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -34,7 +34,7 @@ IQE_FILTER_EXPRESSION="test_page"
 # with values not suitable for other scripts
 export APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
 export REF_ENV="insights-stage"
-export COMPONENT_NAME="ocp-advisor-frontend"
+export COMPONENT_NAME="ocp-advisor-frontend"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 # no need for all components, only the ones that process archives
 export COMPONENTS="ocp-advisor-frontend ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 export DEPLOY_FRONTENDS="true"
@@ -52,7 +52,7 @@ export IQE_CJI_TIMEOUT="30m"
 # shellcheck source=/dev/null
 source "${CICD_ROOT}/deploy_ephemeral_env.sh"
 # shellcheck source=/dev/null
-export COMPONENT_NAME="ocp-advisor"
+export COMPONENT_NAME="ccx-data-pipeline"  # component name needs to be re-export to match ClowdApp name (as bonfire requires for this)
 source "${CICD_ROOT}/cji_smoke_test.sh"
 # shellcheck source=/dev/null
 source "${CICD_ROOT}/post_test_results.sh"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -33,16 +33,17 @@ IQE_FILTER_EXPRESSION="test_page"
 # some variables need to be exported after build because frontend-build overrides them
 # with values not suitable for other scripts
 export APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
-export COMPONENT_NAME="ocp-advisor-frontend"
 export REF_ENV="insights-stage"
-
+export COMPONENT_NAME="ocp-advisor-frontend"
+# no need for all components, only the ones that process archives
+export COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 export DEPLOY_FRONTENDS="true"
 export IQE_ENV="ephemeral"
 export IQE_SELENIUM="true"
 export IQE_CJI_TIMEOUT="30m"
 
 #COMPONENTS_W_RESOURCES=""
-#COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
+
 
 
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,7 +27,7 @@ export IQE_CJI_TIMEOUT="30m"
 
 REF_ENV="insights-production"
 #COMPONENTS_W_RESOURCES=""
-export COMPONENT_NAME="ocp-advisor"
+export COMPONENT_NAME="ocp-advisor-frontend"
 #COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -44,7 +44,7 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 # shellcheck source=/dev/null
 source "${CICD_ROOT}/deploy_ephemeral_env.sh"
 # shellcheck source=/dev/null
-#export COMPONENT_NAME="compliance"
+export COMPONENT_NAME="ocp-advisor"
 source "${CICD_ROOT}/cji_smoke_test.sh"
 # shellcheck source=/dev/null
 source "${CICD_ROOT}/post_test_results.sh"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -20,8 +20,9 @@ IQE_PLUGINS="ccx"
 IQE_MARKER_EXPRESSION="ui"
 IQE_FILTER_EXPRESSION="test_page"
 
-APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
-REF_ENV="insights-stage"
+export APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
+export COMPONENT_NAME="ocp-advisor-frontend"
+export REF_ENV="insights-stage"
 
 export DEPLOY_FRONTENDS="true"
 export IQE_ENV="ephemeral"
@@ -29,7 +30,6 @@ export IQE_SELENIUM="true"
 export IQE_CJI_TIMEOUT="30m"
 
 #COMPONENTS_W_RESOURCES=""
-export COMPONENT_NAME="ocp-advisor-frontend"
 #COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,7 +27,7 @@ export IQE_CJI_TIMEOUT="30m"
 
 REF_ENV="insights-production"
 #COMPONENTS_W_RESOURCES=""
-export COMPONENT_NAME="ocp-advisor
+export COMPONENT_NAME="ocp-advisor"
 #COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -20,12 +20,14 @@ IQE_PLUGINS="ccx"
 IQE_MARKER_EXPRESSION="ui"
 IQE_FILTER_EXPRESSION="test_page"
 
+APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
+REF_ENV="insights-stage"
+
 export DEPLOY_FRONTENDS="true"
 export IQE_ENV="ephemeral"
 export IQE_SELENIUM="true"
 export IQE_CJI_TIMEOUT="30m"
 
-REF_ENV="insights-stage"
 #COMPONENTS_W_RESOURCES=""
 export COMPONENT_NAME="ocp-advisor-frontend"
 #COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -36,7 +36,7 @@ export APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this
 export REF_ENV="insights-stage"
 export COMPONENT_NAME="ocp-advisor-frontend"
 # no need for all components, only the ones that process archives
-export COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
+export COMPONENTS="ocp-advisor-frontend ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 export DEPLOY_FRONTENDS="true"
 export IQE_ENV="ephemeral"
 export IQE_SELENIUM="true"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -25,7 +25,7 @@ export IQE_ENV="ephemeral"
 export IQE_SELENIUM="true"
 export IQE_CJI_TIMEOUT="30m"
 
-REF_ENV="insights-production"
+REF_ENV="insights-stage"
 #COMPONENTS_W_RESOURCES=""
 export COMPONENT_NAME="ocp-advisor-frontend"
 #COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -16,10 +16,22 @@ COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-fronten
 # --------------------------------------------
 # Options that must be configured by app owner
 # --------------------------------------------
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+
+# Install bonfire repo/initialize
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+# shellcheck source=/dev/null
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+
 IQE_PLUGINS="ccx"
 IQE_MARKER_EXPRESSION="ui"
 IQE_FILTER_EXPRESSION="test_page"
 
+# some variables need to be exported after build because frontend-build overrides them
+# with values not suitable for other scripts
 export APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="ocp-advisor-frontend"
 export REF_ENV="insights-stage"
@@ -33,14 +45,7 @@ export IQE_CJI_TIMEOUT="30m"
 #COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod"
 
 
-set -exv
-# source is preferred to | bash -s in this case to avoid a subshell
-source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
 
-# Install bonfire repo/initialize
-CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
-# shellcheck source=/dev/null
-curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 # Run smoke tests
 # shellcheck source=/dev/null


### PR DESCRIPTION
This MR enables the use of IQE CCX plugin tests for validating UI deployments.  CCXDEV-10136

It is just a PoC that it works. 

I am a bit concerned about having to rename the COMPONENT_NAME before running the tests and not being able to use `ocp-advisor` for that (`export COMPONENT_NAME="ccx-data-pipeline"`)