### PR TITLE
chore(OCPADVISOR-63): Upgrade react-router-dom library to version 6

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -30,6 +30,11 @@ plugins.push(
       exposes: {
         './RootApp': resolve(__dirname, '../src/AppEntry'),
       },
+      shared: [
+        {
+          'react-router-dom': { singleton: true, requiredVersion: '*' },
+        },
+      ],
     }
   )
 );

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -16,6 +16,11 @@ plugins.push(
       exposes: {
         './RootApp': resolve(__dirname, '../src/AppEntry'),
       },
+      shared: [
+        {
+          'react-router-dom': { singleton: true, requiredVersion: '*' },
+        },
+      ],
     }
   )
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react-intl": "^6.2.5",
         "react-markdown": "^8.0.3",
         "react-redux": "^8.0.5",
-        "react-router-dom": "^5.3.4",
+        "react-router-dom": "^6.6.1",
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6",
         "semver": "^7.3.8"
@@ -4248,6 +4248,14 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@scalprum/core": {
@@ -11178,19 +11186,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -12626,11 +12621,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -19737,14 +19727,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -20837,45 +20819,34 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.3.2"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
@@ -21603,11 +21574,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve.exports": {
       "version": "1.1.0",
@@ -23637,16 +23603,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/tippy.js": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.1.2.tgz",
@@ -24334,11 +24290,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -28346,6 +28297,11 @@
         "redux-thunk": "^2.4.2",
         "reselect": "^4.1.7"
       }
+    },
+    "@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA=="
     },
     "@scalprum/core": {
       "version": "0.2.3",
@@ -33769,19 +33725,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -34798,11 +34741,6 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -39836,14 +39774,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -40621,40 +40551,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
+        "@remix-run/router": "1.3.2"
       }
     },
     "react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
       }
     },
     "read-pkg": {
@@ -41201,11 +41111,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve.exports": {
       "version": "1.1.0",
@@ -42748,16 +42653,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "tippy.js": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.1.2.tgz",
@@ -43268,11 +43163,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-intl": "^6.2.5",
     "react-markdown": "^8.0.3",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^5.3.4",
+    "react-router-dom": "^6.6.1",
     "redux": "^4.2.0",
     "redux-logger": "^3.0.6",
     "semver": "^7.3.8"

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import './App.scss';
 
 import React, { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -13,7 +13,7 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 import LockIcon from '@patternfly/react-icons/dist/js/icons/lock-icon';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { Routes } from './Routes';
+import { AppRoutes } from './Routes';
 import ErrorBoundary from './Utilities/ErrorBoundary';
 import MessageState from './Components/MessageState/MessageState';
 import messages from './Messages';
@@ -21,7 +21,7 @@ import getStore from './Store';
 
 const App = ({ useLogger, basename }) => {
   const intl = useIntl();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const chrome = useChrome();
@@ -31,14 +31,13 @@ const App = ({ useLogger, basename }) => {
     if (chrome) {
       const registry = getRegistry();
       registry.register({ notifications: notificationsReducer });
-      const { on: onChromeEvent } = chrome.init();
 
-      unregister = onChromeEvent('APP_NAVIGATION', (event) => {
+      unregister = chrome.on('APP_NAVIGATION', (event) => {
         const targetUrl = event.domEvent?.href
           ?.replace(basename, '/')
           .replace(/^\/\//, '/');
         if (typeof targetUrl === 'string') {
-          history.push(targetUrl);
+          navigate(targetUrl);
         }
       });
       chrome.auth.getUser().then(() => {
@@ -58,7 +57,7 @@ const App = ({ useLogger, basename }) => {
       ) : isAuthenticated ? (
         <Provider store={getStore(useLogger)}>
           <NotificationsPortal />
-          <Routes />
+          <AppRoutes />
         </Provider>
       ) : (
         <Bullseye>

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { BrowserRouter as Router } from 'react-router-dom';
 
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers/helpers';
 
@@ -11,9 +10,7 @@ const AppEntry = ({ useLogger }) => {
   const basename = getBaseName(window.location.pathname, 3);
   return (
     <Intl>
-      <Router basename={basename}>
-        <App useLogger={useLogger} basename={basename.replace('/beta/', '/')} />
-      </Router>
+      <App useLogger={useLogger} basename={basename.replace('/beta/', '/')} />
     </Intl>
   );
 };

--- a/src/Components/AffectedClustersTable/AffectedClustersTable.js
+++ b/src/Components/AffectedClustersTable/AffectedClustersTable.js
@@ -40,6 +40,7 @@ import {
   removeFilterParam as _removeFilterParam,
   addFilterParam as _addFilterParam,
 } from '../Common/Tables';
+import { BASE_PATH } from '../../Routes';
 
 const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
   const intl = useIntl();
@@ -205,7 +206,7 @@ const AffectedClustersTable = ({ query, rule, afterDisableFn }) => {
         ...r,
         cells: [
           <span key={r.id}>
-            <Link to={`/clusters/${r.id}?first=${rule.rule_id}`}>
+            <Link to={`${BASE_PATH}/clusters/${r.id}?first=${rule.rule_id}`}>
               {r.cells[AFFECTED_CLUSTERS_NAME_CELL]}
             </Link>
           </span>,

--- a/src/Components/Breadcrumbs/Breadcrumbs.cy.js
+++ b/src/Components/Breadcrumbs/Breadcrumbs.cy.js
@@ -15,7 +15,9 @@ describe('breadcrumbs', () => {
     };
     mount(
       <MemoryRouter
-        initialEntries={['/recommendations/ccxdev.external.123|ERROR_KEY']}
+        initialEntries={[
+          '/openshift/insights/advisor/recommendations/ccxdev.external.123|ERROR_KEY',
+        ]}
         initialIndex={0}
       >
         <IntlProvider locale="en">
@@ -30,7 +32,11 @@ describe('breadcrumbs', () => {
     cy.get(BREADCRUMB_ITEM)
       .eq(0)
       .find('a')
-      .should('have.attr', 'href', '/recommendations');
+      .should(
+        'have.attr',
+        'href',
+        '/openshift/insights/advisor/recommendations'
+      );
     cy.get(BREADCRUMB_ITEM)
       .eq(1)
       .should(
@@ -46,7 +52,9 @@ describe('breadcrumbs', () => {
     };
     mount(
       <MemoryRouter
-        initialEntries={['/clusters/d6964a24-a78c-4bdc-8100-17e797efe3d3']}
+        initialEntries={[
+          '/openshift/insights/advisor/clusters/d6964a24-a78c-4bdc-8100-17e797efe3d3',
+        ]}
         initialIndex={0}
       >
         <IntlProvider locale="en">
@@ -59,7 +67,7 @@ describe('breadcrumbs', () => {
     cy.get(BREADCRUMB_ITEM)
       .eq(0)
       .find('a')
-      .should('have.attr', 'href', '/clusters');
+      .should('have.attr', 'href', '/openshift/insights/advisor/clusters');
     cy.get(BREADCRUMB_ITEM).eq(1).should('have.text', 'Cluster with issues');
     cy.get(BREADCRUMB_ITEM).eq(1).find('span').should('have.length', 1);
   });

--- a/src/Components/Breadcrumbs/index.js
+++ b/src/Components/Breadcrumbs/index.js
@@ -16,8 +16,8 @@ const Breadcrumbs = ({ current }) => {
     <div>
       <Breadcrumb ouiaId="detail">
         <BreadcrumbItem className="breadcrumb-item">
-          <Link to={`/${splitUrl[1]}`}>
-            {`${intl.formatMessage(messages.insightsHeader)} ${splitUrl[1]}`}
+          <Link to={`..`} relative="path">
+            {`${intl.formatMessage(messages.insightsHeader)} ${splitUrl[4]}`}
           </Link>
         </BreadcrumbItem>
         <BreadcrumbItem className="breadcrumb-item" isActive>

--- a/src/Components/Cluster/Cluster.cy.js
+++ b/src/Components/Cluster/Cluster.cy.js
@@ -36,12 +36,7 @@ describe('cluster page', () => {
       displayName: {
         data: singleClusterPageReport.report.meta.cluster_name,
       },
-      match: {
-        params: {
-          clusterId: 'foobar',
-        },
-        url: 'foobar',
-      },
+      clusterId: 'foobar',
     };
   });
 
@@ -179,12 +174,7 @@ describe('Cluster page display name test №1', () => {
         isSuccess: true,
         data: singleClusterPageReport,
       },
-      match: {
-        params: {
-          clusterId: 'Cluster Id',
-        },
-        url: 'foobar',
-      },
+      clusterId: 'Cluster Id',
     };
   });
 

--- a/src/Components/Cluster/Cluster.js
+++ b/src/Components/Cluster/Cluster.js
@@ -8,16 +8,13 @@ import ClusterHeader from '../ClusterHeader';
 import ClusterRules from '../ClusterRules/ClusterRules';
 import Breadcrumbs from '../Breadcrumbs';
 
-export const Cluster = ({ cluster, match }) => {
+export const Cluster = ({ cluster, clusterId }) => {
   // TODO: make breadcrumbs take display name from GET /cluster/id/info
   return (
     <React.Fragment>
       <PageHeader className="pf-m-light ins-inventory-detail">
         <Breadcrumbs
-          current={
-            cluster?.data?.report.meta.cluster_name || match.params.clusterId
-          }
-          match={match}
+          current={cluster?.data?.report.meta.cluster_name || clusterId}
         />
         <ClusterHeader />
       </PageHeader>
@@ -31,5 +28,5 @@ export const Cluster = ({ cluster, match }) => {
 Cluster.propTypes = {
   cluster: PropTypes.object.isRequired,
   displayName: PropTypes.object.isRequired,
-  match: PropTypes.object.isRequired,
+  clusterId: PropTypes.string.isRequired,
 };

--- a/src/Components/Cluster/index.js
+++ b/src/Components/Cluster/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
@@ -9,26 +9,26 @@ import { Cluster } from './Cluster';
 
 const ClusterWrapper = () => {
   const intl = useIntl();
-  const match = useRouteMatch();
+  const { clusterId } = useParams();
   const cluster = useGetClusterByIdQuery({
-    id: match.params.clusterId,
+    id: clusterId,
     includeDisabled: false,
   });
   const chrome = useChrome();
 
   useEffect(() => {
     cluster.refetch();
-  }, [match.params.clusterId]);
+  }, [clusterId]);
 
   useEffect(() => {
     const subnav = `${
-      cluster?.data?.report?.meta?.cluster_name || match.params.clusterId
+      cluster?.data?.report?.meta?.cluster_name || clusterId
     } - ${intl.formatMessage(messages.clusters)}`;
     chrome.updateDocumentTitle(
       intl.formatMessage(messages.documentTitle, { subnav })
     );
-  }, [cluster, match]);
-  return <Cluster cluster={cluster} match={match} />;
+  }, [cluster, clusterId]);
+  return <Cluster cluster={cluster} clusterId={clusterId} />;
 };
 
 export default ClusterWrapper;

--- a/src/Components/ClusterHeader/index.js
+++ b/src/Components/ClusterHeader/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import {
   useGetClusterByIdQuery,
@@ -8,8 +8,7 @@ import {
 import { ClusterHeader } from './ClusterHeader';
 
 const ClusterHeaderWrapper = () => {
-  const match = useRouteMatch();
-  const clusterId = match.params.clusterId;
+  const { clusterId } = useParams();
   const clusterData = useGetClusterByIdQuery({
     id: clusterId,
     includeDisabled: false,

--- a/src/Components/ClusterRules/ClusterRules.cy.js
+++ b/src/Components/ClusterRules/ClusterRules.cy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from '@cypress/react';
 import { IntlProvider } from 'react-intl';
-import { MemoryRouter, Route } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import _ from 'lodash';
 
@@ -135,20 +135,20 @@ describe('cluster rules table', () => {
       <IntlProvider locale="en">
         <Provider store={getStore()}>
           <MemoryRouter
-            initialEntries={['/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258']}
+            initialEntries={[
+              '/openshift/insights/advisor/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258',
+            ]}
             initialIndex={0}
           >
-            <Route path="/clusters/:clusterId">
-              <ClusterRules
-                cluster={{
-                  isError: false,
-                  isFetching: false,
-                  isUninitialized: false,
-                  isSuccess: true,
-                  data: { report: { data } },
-                }}
-              />
-            </Route>
+            <ClusterRules
+              cluster={{
+                isError: false,
+                isFetching: false,
+                isUninitialized: false,
+                isSuccess: true,
+                data: { report: { data } },
+              }}
+            />
           </MemoryRouter>
         </Provider>
       </IntlProvider>
@@ -321,20 +321,20 @@ describe('empty cluster rules table', () => {
       <IntlProvider locale="en">
         <Provider store={getStore()}>
           <MemoryRouter
-            initialEntries={['/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258']}
+            initialEntries={[
+              '/openshift/insights/advisor/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258',
+            ]}
             initialIndex={0}
           >
-            <Route path="/clusters/:clusterId">
-              <ClusterRules
-                cluster={{
-                  isError: false,
-                  isFetching: false,
-                  isUninitialized: false,
-                  isSuccess: true,
-                  data: { report: { data: [] } },
-                }}
-              />
-            </Route>
+            <ClusterRules
+              cluster={{
+                isError: false,
+                isFetching: false,
+                isUninitialized: false,
+                isSuccess: true,
+                data: { report: { data: [] } },
+              }}
+            />
           </MemoryRouter>
         </Provider>
       </IntlProvider>
@@ -357,26 +357,26 @@ describe('empty cluster rules table', () => {
   });
 });
 
-describe('no rules cluster', () => {
+describe.only('no rules cluster', () => {
   beforeEach(() => {
     mount(
       <IntlProvider locale="en">
         <Provider store={getStore()}>
           <MemoryRouter
-            initialEntries={['/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258']}
+            initialEntries={[
+              '/openshift/insights/advisor/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258',
+            ]}
             initialIndex={0}
           >
-            <Route path="/clusters/:clusterId">
-              <ClusterRules
-                cluster={{
-                  isError: true,
-                  isFetching: false,
-                  isUninitialized: false,
-                  isSuccess: false,
-                  error: { status: 404 },
-                }}
-              />
-            </Route>
+            <ClusterRules
+              cluster={{
+                isError: true,
+                isFetching: false,
+                isUninitialized: false,
+                isSuccess: false,
+                error: { status: 404 },
+              }}
+            />
           </MemoryRouter>
         </Provider>
       </IntlProvider>
@@ -411,20 +411,20 @@ describe('error response other than 404', () => {
       <IntlProvider locale="en">
         <Provider store={getStore()}>
           <MemoryRouter
-            initialEntries={['/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258']}
+            initialEntries={[
+              '/openshift/insights/advisor/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258',
+            ]}
             initialIndex={0}
           >
-            <Route path="/clusters/:clusterId">
-              <ClusterRules
-                cluster={{
-                  isError: true,
-                  isFetching: false,
-                  isUninitialized: false,
-                  isSuccess: false,
-                  error: { status: 500 },
-                }}
-              />
-            </Route>
+            <ClusterRules
+              cluster={{
+                isError: true,
+                isFetching: false,
+                isUninitialized: false,
+                isSuccess: false,
+                error: { status: 500 },
+              }}
+            />
           </MemoryRouter>
         </Provider>
       </IntlProvider>
@@ -459,21 +459,19 @@ describe('cluster rules table testing the first query parameter', () => {
         <Provider store={getStore()}>
           <MemoryRouter
             initialEntries={[
-              '/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258?first=external.rules.rule_n_one|ERROR_KEY_N2',
+              '/openshift/insights/advisor/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258?first=external.rules.rule_n_one|ERROR_KEY_N2',
             ]}
             initialIndex={0}
           >
-            <Route path="/clusters/:clusterId">
-              <ClusterRules
-                cluster={{
-                  isError: false,
-                  isFetching: false,
-                  isUninitialized: false,
-                  isSuccess: true,
-                  data: { report: { data: data_first_query_parameter } },
-                }}
-              />
-            </Route>
+            <ClusterRules
+              cluster={{
+                isError: false,
+                isFetching: false,
+                isUninitialized: false,
+                isSuccess: true,
+                data: { report: { data: data_first_query_parameter } },
+              }}
+            />
           </MemoryRouter>
         </Provider>
       </IntlProvider>

--- a/src/Components/ClustersListTable/ClustersListTable.cy.js
+++ b/src/Components/ClustersListTable/ClustersListTable.cy.js
@@ -217,7 +217,7 @@ urlParamsList.forEach((urlParams, index) => {
     beforeEach(() => {
       mount(
         <MemoryRouter
-          initialEntries={[`/clusters?${urlParams}`]}
+          initialEntries={[`/openshift/insights/advisor/clusters?${urlParams}`]}
           initialIndex={0}
         >
           <Intl>
@@ -267,7 +267,10 @@ urlParamsList.forEach((urlParams, index) => {
 describe('clusters list table', () => {
   beforeEach(() => {
     mount(
-      <MemoryRouter initialEntries={['/clusters']} initialIndex={0}>
+      <MemoryRouter
+        initialEntries={['/openshift/insights/advisor/clusters']}
+        initialIndex={0}
+      >
         <Intl>
           <Provider store={getStore()}>
             <ClustersListTable
@@ -518,7 +521,9 @@ describe('clusters list table', () => {
       .each(($el, index) => {
         cy.wrap($el)
           .find('td[data-label=Name]')
-          .find(`a[href="/clusters/${data[index]['cluster_id']}"]`)
+          .find(
+            `a[href="/openshift/insights/advisor/clusters/${data[index]['cluster_id']}"]`
+          )
           .should('have.text', data[index]['name']);
       });
   });
@@ -553,7 +558,10 @@ describe('clusters list table', () => {
 describe('cluster list Empty state rendering', () => {
   beforeEach(() => {
     mount(
-      <MemoryRouter initialEntries={['/clusters']} initialIndex={0}>
+      <MemoryRouter
+        initialEntries={['/openshift/insights/advisor/clusters']}
+        initialIndex={0}
+      >
         <Intl>
           <Provider store={getStore()}>
             <ClustersListTable

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -53,6 +53,7 @@ import {
   NoRecsForClusters,
 } from '../MessageState/EmptyStates';
 import { coerce } from 'semver';
+import { BASE_PATH } from '../../Routes';
 
 const ClustersListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
@@ -149,7 +150,7 @@ const ClustersListTable = ({
         entity: it,
         cells: [
           <span key={index}>
-            <Link to={`clusters/${it.cluster_id}`}>
+            <Link to={`${BASE_PATH}/clusters/${it.cluster_id}`}>
               {it.cluster_name || it.cluster_id}
             </Link>
           </span>,

--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -23,6 +23,7 @@ import DefaultErrorMessage from '@redhat-cloud-services/frontend-components/Erro
 
 import MessageState from './MessageState';
 import messages from '../../Messages';
+import { BASE_PATH } from '../../Routes';
 
 // Analogue for ErrorState from the frontend-components without the "Go to homepage" button
 // TODO: update ErrorState from the frontend-components and remove custom error here
@@ -90,7 +91,7 @@ const ComingSoon = () => {
       <EmptyStateBody>
         {intl.formatMessage(messages.comingSoonBody)}
       </EmptyStateBody>
-      <Link to="/recommendations">
+      <Link to={`${BASE_PATH}/recommendations`}>
         <Button variant="primary">Recommendations</Button>
       </Link>
     </EmptyState>

--- a/src/Components/Recommendation/Recommendation.cy.js
+++ b/src/Components/Recommendation/Recommendation.cy.js
@@ -55,7 +55,7 @@ describe('recommendation page for enabled recommendation with clusters enabled a
               rule={{ ...defaultPropsRule }}
               ack={{ ...defaultPropsAck, data: undefined }}
               clusters={{ ...defaultPropsClusterDetails }}
-              match={{ params: { recommendationId: 'X' } }}
+              recId="X"
             />
           </Provider>
         </Intl>
@@ -207,7 +207,7 @@ describe('recommendation page for enabled recommedation with nulled resolution r
               rule={{ ...defaultPropsRule, data: nulledResolutionRisk }}
               ack={{ ...defaultPropsAck, data: undefined }}
               clusters={{ ...defaultPropsClusterDetails }}
-              match={{ params: { recommendationId: 'X' } }}
+              recId="X"
             />
           </Provider>
         </Intl>
@@ -234,7 +234,7 @@ describe('recommendation page for enabled recommendation without disabled cluste
               rule={{ ...defaultPropsRule }}
               ack={{ ...defaultPropsAck, data: undefined }}
               clusters={{ ...defaultPropsClusterDetails, data: data }}
-              match={{ params: { recommendationId: 'X' } }}
+              recId="X"
             />
           </Provider>
         </Intl>
@@ -290,7 +290,7 @@ describe('recommendation page for disabled recommendation', () => {
               rule={{ ...defaultPropsRule, data: disabledRule }}
               ack={{ ...defaultPropsAck }}
               clusters={{ ...defaultPropsClusterDetails }}
-              match={{ params: { recommendationId: 'X' } }}
+              recId="X"
             />
           </Provider>
         </Intl>
@@ -366,7 +366,7 @@ describe('justification message', () => {
                   data: { ...ack, ...{ justification: '' } },
                 }}
                 clusters={{ ...defaultPropsClusterDetails }}
-                match={{ params: { recommendationId: 'X' } }}
+                recId="X"
               />
             </Provider>
           </Intl>
@@ -399,7 +399,7 @@ describe('justification message', () => {
                   data: { ...ack, ...{ justification: justification } },
                 }}
                 clusters={{ ...defaultPropsClusterDetails }}
-                match={{ params: { recommendationId: 'X' } }}
+                recId="X"
               />
             </Provider>
           </Intl>
@@ -473,7 +473,7 @@ describe('category labels are displayed', () => {
                   rule={{ ...defaultPropsRule, data: taggedRule }}
                   ack={{ ...defaultPropsAck, data: undefined }}
                   clusters={{ ...defaultPropsClusterDetails }}
-                  match={{ params: { recommendationId: 'X' } }}
+                  recId="X"
                 />
               </Provider>
             </Intl>

--- a/src/Components/Recommendation/Recommendation.js
+++ b/src/Components/Recommendation/Recommendation.js
@@ -58,11 +58,10 @@ import { enableRuleForCluster } from '../../Services/Acks';
 import { formatMessages, mapContentToValues } from '../../Utilities/intlHelper';
 import inRange from 'lodash/inRange';
 
-const Recommendation = ({ rule, ack, clusters, match }) => {
+const Recommendation = ({ rule, ack, clusters, recId }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const notify = (data) => dispatch(addNotification(data));
-  const recId = match.params.recommendationId;
   const [disableRuleModalOpen, setDisableRuleModalOpen] = useState(false);
   const [actionsDropdownOpen, setActionsDropdownOpen] = useState(false);
   const [viewSystemsModalOpen, setViewSystemsModalOpen] = useState(false);
@@ -456,7 +455,7 @@ Recommendation.propTypes = {
   rule: PropTypes.object.isRequired,
   ack: PropTypes.object.isRequired,
   clusters: PropTypes.object.isRequired,
-  match: PropTypes.object.isRequired,
+  recId: PropTypes.string.isRequired,
 };
 
 export { Recommendation };

--- a/src/Components/Recommendation/index.js
+++ b/src/Components/Recommendation/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useParams, useRouteMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
@@ -13,8 +13,9 @@ import messages from '../../Messages';
 
 const RecommendationWrapper = () => {
   const intl = useIntl();
-  const rule = useGetRuleByIdQuery(useParams().recommendationId);
-  const ack = useGetRecAcksQuery({ ruleId: useParams().recommendationId });
+  const { recommendationId } = useParams();
+  const rule = useGetRuleByIdQuery(recommendationId);
+  const ack = useGetRecAcksQuery({ ruleId: recommendationId });
   const chrome = useChrome();
 
   if (rule.isSuccess && rule.data?.content?.description) {
@@ -23,18 +24,18 @@ const RecommendationWrapper = () => {
       intl.formatMessage(messages.documentTitle, { subnav })
     );
   }
-  const clusters = useGetAffectedClustersQuery(useParams().recommendationId);
+  const clusters = useGetAffectedClustersQuery(recommendationId);
 
   useEffect(() => {
     rule.refetch();
-  }, [useParams().recommendationId]);
+  }, [recommendationId]);
 
   return (
     <Recommendation
       rule={rule}
       ack={ack}
       clusters={clusters}
-      match={useRouteMatch()}
+      recId={recommendationId}
     />
   );
 };

--- a/src/Components/RecsListTable/RecsListTable.cy.js
+++ b/src/Components/RecsListTable/RecsListTable.cy.js
@@ -285,7 +285,9 @@ urlParamsList.forEach((urlParams, index) => {
     beforeEach(() => {
       mount(
         <MemoryRouter
-          initialEntries={[`/recommendations?${urlParams}`]}
+          initialEntries={[
+            `/openshift/insights/advisor/recommendations?${urlParams}`,
+          ]}
           initialIndex={0}
         >
           <Intl>
@@ -330,7 +332,10 @@ urlParamsList.forEach((urlParams, index) => {
 describe('successful non-empty recommendations list table', () => {
   beforeEach(() => {
     mount(
-      <MemoryRouter initialEntries={['/recommendations']} initialIndex={0}>
+      <MemoryRouter
+        initialEntries={['/openshift/insights/advisor/recommendations']}
+        initialIndex={0}
+      >
         <Intl>
           <Provider store={getStore()}>
             <RecsListTable
@@ -789,7 +794,10 @@ describe('successful non-empty recommendations list table', () => {
 describe('empty recommendations list table', () => {
   beforeEach(() => {
     mount(
-      <MemoryRouter initialEntries={['/recommendations']} initialIndex={0}>
+      <MemoryRouter
+        initialEntries={['/openshift/insights/advisor/recommendations']}
+        initialIndex={0}
+      >
         <Intl>
           <Provider store={getStore()}>
             <RecsListTable
@@ -815,7 +823,10 @@ describe('empty recommendations list table', () => {
 describe('error recommendations list table', () => {
   beforeEach(() => {
     mount(
-      <MemoryRouter initialEntries={['/recommendations']} initialIndex={0}>
+      <MemoryRouter
+        initialEntries={['/openshift/insights/advisor/recommendations']}
+        initialIndex={0}
+      >
         <Intl>
           <Provider store={getStore()}>
             <RecsListTable

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -67,6 +67,7 @@ import {
 import { adjustOCPRule } from '../../Utilities/Rule';
 import Loading from '../Loading/Loading';
 import inRange from 'lodash/inRange';
+import { BASE_PATH } from '../../Routes';
 
 const RecsListTable = ({ query }) => {
   const intl = useIntl();
@@ -173,7 +174,10 @@ const RecsListTable = ({ query }) => {
             {
               title: (
                 <span key={key}>
-                  <Link key={key} to={`/recommendations/${value.rule_id}`}>
+                  <Link
+                    key={key}
+                    to={`${BASE_PATH}/recommendations/${value.rule_id}`}
+                  >
                     {' '}
                     {value?.description || value?.rule_id}{' '}
                   </Link>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,4 +1,4 @@
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import React, { Suspense, lazy } from 'react';
 
 import {
@@ -25,34 +25,9 @@ const ClustersList = lazy(() =>
   import(/* webpackChunkName: "ClustersList" */ './Components/ClustersList')
 );
 
-const paths = [
-  {
-    title: 'Clusters',
-    path: '/clusters/:clusterId',
-    component: Cluster,
-  },
-  { title: 'Clusters', path: '/clusters', component: ClustersList },
-  {
-    title: 'Recommendations',
-    path: '/recommendations/:recommendationId',
-    component: Recommendation,
-  },
-  {
-    title: 'Recommendations',
-    path: '/recommendations',
-    component: RecsList,
-  },
-];
+export const BASE_PATH = '/openshift/insights/advisor';
 
-/**
- * the Switch component changes routes depending on the path.
- *
- * Route properties:
- *      exact - path must match exactly,
- *      path - https://prod.foo.redhat.com:1337/insights/advisor/rules
- *      component - component to be rendered when a route has been chosen.
- */
-export const Routes = () => (
+export const AppRoutes = () => (
   <Suspense
     fallback={
       <Bullseye>
@@ -60,22 +35,28 @@ export const Routes = () => (
       </Bullseye>
     }
   >
-    <Switch>
-      {paths.map((path) => (
-        <Route key={path.title} path={path.path} component={path.component} />
-      ))}
-      <Redirect exact from="/" to="/recommendations" />
-      {/* Finally, catch all unmatched routes */}
+    <Routes>
+      <Route path="/clusters/:clusterId" element={<Cluster />} />
+      <Route path="/clusters" element={<ClustersList />} />
+      <Route
+        path="/recommendations/:recommendationId"
+        element={<Recommendation />}
+      />
+      <Route path="/recommendations" element={<RecsList />} />
+      <Route
+        path="/"
+        element={<Navigate to={`${BASE_PATH}/recommendations`} replace />}
+      />
       <Route
         path="*"
-        component={() => (
+        element={
           <EmptyState>
             <EmptyStateBody>
               <InvalidObject />
             </EmptyStateBody>
           </EmptyState>
-        )}
+        }
       />
-    </Switch>
+    </Routes>
   </Suspense>
 );


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-63.

This upgrades one of the dependencies react-router-dom to major version 6; makes the library a singletone with chroming; removes deprecated function calls.