### PR TITLE
fix(OCPADVISOR-59): Fix not loading pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.3.13",
         "@redhat-cloud-services/rule-components": "^3.2.6",
-        "@reduxjs/toolkit": "^1.9.0",
+        "@reduxjs/toolkit": "1.8.6",
         "axios": "^0.27.2",
         "babel-plugin-formatjs": "^10.3.31",
         "classnames": "^2.3.1",
@@ -4228,14 +4228,14 @@
       "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.0.tgz",
-      "integrity": "sha512-ak11IrjYcUXRqlhNPwnz6AcvA2ynJTu8PzDbbqQw4a3xR4KZtgiqbNblQD+10CRbfK4+5C79SOyxnT9dhBqFnA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.6.tgz",
+      "integrity": "sha512-4Ia/Loc6WLmdSOzi7k5ff7dLK8CgG2b8aqpLsCAJhazAzGdp//YBUSaj0ceW6a3kDBDNRrq5CRwyCS0wBiL1ig==",
       "dependencies": {
-        "immer": "^9.0.16",
-        "redux": "^4.2.0",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.7"
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
@@ -28288,14 +28288,14 @@
       "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
     },
     "@reduxjs/toolkit": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.0.tgz",
-      "integrity": "sha512-ak11IrjYcUXRqlhNPwnz6AcvA2ynJTu8PzDbbqQw4a3xR4KZtgiqbNblQD+10CRbfK4+5C79SOyxnT9dhBqFnA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.6.tgz",
+      "integrity": "sha512-4Ia/Loc6WLmdSOzi7k5ff7dLK8CgG2b8aqpLsCAJhazAzGdp//YBUSaj0ceW6a3kDBDNRrq5CRwyCS0wBiL1ig==",
       "requires": {
-        "immer": "^9.0.16",
-        "redux": "^4.2.0",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.7"
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
       }
     },
     "@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
     "@redhat-cloud-services/frontend-components-utilities": "^3.3.13",
     "@redhat-cloud-services/rule-components": "^3.2.6",
-    "@reduxjs/toolkit": "^1.9.0",
+    "@reduxjs/toolkit": "1.8.6",
     "axios": "^0.27.2",
     "babel-plugin-formatjs": "^10.3.31",
     "classnames": "^2.3.1",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPADVISOR-59.

This should fix the bug when the users navigated to the cluster or recommendation details page for the second and further times and couldn't see data loaded.

[Screencast from 03-08-2023 01:48:38 PM.webm](https://user-images.githubusercontent.com/31385370/223717362-1c77476e-bc54-403e-8416-f02ec337b06d.webm)

## How to test

Navigate to recommendation/id or cluster/id pages. Go back to the recommendations/clusters list table via breadcrumbs. Go again to any of the details pages. The end page should load fine (whereas for example in production it does not currently).