### PR TITLE
fix: Use correct empty state for 404 upgrade risks

### DIFF
--- a/cypress/utils/interceptors.js
+++ b/cypress/utils/interceptors.js
@@ -104,6 +104,14 @@ export const upgradeRisksInterceptors = {
         statusCode: 503,
       }
     ),
+  'error, not found': () =>
+    cy.intercept(
+      'GET',
+      /\/api\/insights-results-aggregator\/v2\/cluster\/.*\/upgrade-risks-prediction/,
+      {
+        statusCode: 404,
+      }
+    ),
   'error, other': () =>
     cy.intercept(
       'GET',

--- a/src/Components/Cluster/Cluster.cy.js
+++ b/src/Components/Cluster/Cluster.cy.js
@@ -157,8 +157,8 @@ describe('upgrade risks banner', () => {
     });
   });
 
-  it('upgrade risks service not available', () => {
-    upgradeRisksInterceptors['error, not available']();
+  it('upgrade risks not found', () => {
+    upgradeRisksInterceptors['error, not found']();
     mount();
 
     cy.get(ALERT).should('have.class', 'pf-m-warning');

--- a/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
+++ b/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
@@ -33,7 +33,7 @@ const UpgradeRisksAlert = () => {
       isInline
       title={intl.formatMessage(messages.noKnownUpgradeRisks)}
     />
-  ) : isError && error.status === 503 ? (
+  ) : isError && error.status === 404 ? (
     <Alert
       variant="warning"
       isInline

--- a/src/Components/UpgradeRisksTable/UpgradeRisksTable.cy.js
+++ b/src/Components/UpgradeRisksTable/UpgradeRisksTable.cy.js
@@ -177,6 +177,23 @@ describe('error, service down', () => {
   });
 
   it('renders empty state', () => {
+    // can't apply checkEmptyState since "something went wrong" component doesn't use OUIA id
+    cy.get('.pf-c-empty-state h4').should('have.text', 'Something went wrong');
+    cy.get('.pf-c-empty-state__icon').should('be.visible');
+  });
+
+  it('header is present', () => {
+    checkTableHeaders(['Name']);
+  });
+});
+
+describe('error, not found', () => {
+  beforeEach(() => {
+    interceptors['error, not found']();
+    mount();
+  });
+
+  it('renders empty state', () => {
     checkEmptyState('Upgrade risks are not available', true);
   });
 

--- a/src/Components/UpgradeRisksTable/UpgradeRisksTable.js
+++ b/src/Components/UpgradeRisksTable/UpgradeRisksTable.js
@@ -148,29 +148,17 @@ const UpgradeRisksTable = () => {
             </Tr>
           </Tbody>
         </>
-      ) : noRisks ? (
-        <Tbody>
-          <Tr>
-            <Td colSpan={2}>
-              <NoUpgradeRisks />
-            </Td>
-          </Tr>
-        </Tbody>
-      ) : isError && error.status === 503 ? (
-        <Tbody>
-          <Tr>
-            <Td colSpan={2}>
-              <UpgradeRisksNotAvailable />
-              {/* back end is temporarily not available */}
-            </Td>
-          </Tr>
-        </Tbody>
       ) : (
         <Tbody>
           <Tr>
             <Td colSpan={2}>
-              <ErrorState />
-              {/* default state for unexpected errors */}
+              {noRisks ? (
+                <NoUpgradeRisks />
+              ) : isError && error.status === 404 ? (
+                <UpgradeRisksNotAvailable />
+              ) : (
+                <ErrorState />
+              )}
             </Td>
           </Tr>
         </Tbody>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPADVISOR-71.

When upgrade risks back end endpoint responds with 404:

- show "not available" message instead of the table,
- render alert banner above the tabs.

When upgrade risks back end endpoint responds with 503 and other error codes (different from 404):

- show "something went wrong" message instead of the table,
- do not render alert banner above the tabs.

## How to test

As it was described in previous upgrade risks PRs, deploy webpack server together with the mock service. Verify the behavior for clusters that will have 404 or other error codes.