### PR TITLE
feat(OCPADVISOR-86): Render risks with links

### DIFF
--- a/cypress/fixtures/api/insights-results-aggregator/v1/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258/upgrade-risks-prediction.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v1/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258/upgrade-risks-prediction.json
@@ -6,12 +6,14 @@
         {
           "name": "ClusterOperatorDown",
           "namespace": "openshift-monitoring",
-          "severity": "critical"
+          "severity": "critical",
+          "url": "https://redhat.com/alert1"
         },
         {
           "name": "PostDisruptionBudgetLimit",
           "namespace": "openshift-etcd",
-          "severity": "warning"
+          "severity": "warning",
+          "url": "https://redhat.com/alert2"
         },
         {
           "name": "Cluster operators",
@@ -22,12 +24,14 @@
       "operator_conditions": [
         {
           "name": "Version",
-          "condition": "failing"
+          "condition": "failing",
+          "url": "https://redhat.com/oc1"
         },
         {
           "name": "Node-tuning",
           "condition": "degraded",
-          "reason": "Multiple tasks failed"
+          "reason": "Multiple tasks failed",
+          "url": "https://redhat.com/oc2"
         }
       ]
     }

--- a/src/Components/UpgradeRisksTable/AlertsList.js
+++ b/src/Components/UpgradeRisksTable/AlertsList.js
@@ -72,9 +72,11 @@ const AlertsList = () => {
         </Tr>
       </Thead>
       <Tbody>
-        {alerts.map(({ name, namespace, severity }) => (
+        {alerts.map(({ name, namespace, severity, url = '' }) => (
           <Tr key={name}>
-            <Td className="alerts__name">{name}</Td>
+            <Td className="alerts__name">
+              {url === '' ? name : <a href={url}>{name}</a>}
+            </Td>
             <Td className="alerts__severity">
               {ALERTS_SEVERITY_LABEL[severity]}
             </Td>

--- a/src/Components/UpgradeRisksTable/ClusterOperatorsList.js
+++ b/src/Components/UpgradeRisksTable/ClusterOperatorsList.js
@@ -39,9 +39,11 @@ const ClusterOperatorsList = () => {
         </Tr>
       </Thead>
       <Tbody>
-        {conditions.map(({ name, condition, reason }) => (
+        {conditions.map(({ name, condition, reason, url = '' }) => (
           <Tr key={name}>
-            <Td class="operators__name">{name}</Td>
+            <Td class="operators__name">
+              {url === '' ? name : <a href={url}>{name}</a>}
+            </Td>
             <Td class="operators__status">
               <Flex alignItems={{ default: 'alignItemsCenter' }}>
                 <Icon status="warning">

--- a/src/Components/UpgradeRisksTable/UpgradeRisksTable.cy.js
+++ b/src/Components/UpgradeRisksTable/UpgradeRisksTable.cy.js
@@ -81,7 +81,14 @@ describe('successful with some risks', () => {
           const alert =
             upgradeRisksFixtures.upgrade_recommendation.upgrade_risks_predictors
               .alerts[index];
-          cy.get($row).find('.alerts__name').should('have.text', alert.name);
+          if (alert.url) {
+            cy.get($row)
+              .find('.alerts__name a')
+              .should('have.text', alert.name)
+              .and('have.attr', 'href', alert.url);
+          } else {
+            cy.get($row).find('.alerts__name').should('have.text', alert.name);
+          }
           cy.get($row)
             .find('.alerts__severity')
             .should('contain.text', SEVERITY_MAPPING[alert.severity]);
@@ -108,6 +115,16 @@ describe('successful with some risks', () => {
           const condition =
             upgradeRisksFixtures.upgrade_recommendation.upgrade_risks_predictors
               .operator_conditions[index];
+          if (condition.url) {
+            cy.get($row)
+              .find('.operators__name a')
+              .should('have.text', condition.name)
+              .and('have.attr', 'href', condition.url);
+          } else {
+            cy.get($row)
+              .find('.operators__name')
+              .should('have.text', condition.name);
+          }
           cy.get($row)
             .find('.operators__name')
             .should('have.text', condition.name);


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-86.

This makes the upgrade risks table render alerts or operator conditions names in the anchor tag if they have non-null URL provided from the API response.

## How to test

Run the PR with the mock service. Navigate to https://stage.foo.redhat.com:1337/preview/openshift/insights/advisor/clusters/00000003-eeee-eeee-eeee-000000000001?active_tab=upgrade_risks and check that the risks names are rendered as links (`a` tag).

## Screenshots

![image](https://user-images.githubusercontent.com/31385370/233365333-fe10e294-c31e-423e-a239-32e6b62b3dcb.png)
