### PR TITLE
fix(OCPADVISOR-85): Render check icon if no risks

### DIFF
--- a/src/Components/UpgradeRisksTable/AlertsList.js
+++ b/src/Components/UpgradeRisksTable/AlertsList.js
@@ -2,6 +2,7 @@ import { Flex, Icon } from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import {
   TableComposable,
   Tbody,
@@ -28,6 +29,11 @@ export const ALERTS_SEVERITY_ICONS = {
   info: (
     <Icon status="info">
       <InfoCircleIcon />
+    </Icon>
+  ),
+  success: (
+    <Icon status="success">
+      <CheckCircleIcon />
     </Icon>
   ),
 };

--- a/src/Components/UpgradeRisksTable/UpgradeRisksTable.cy.js
+++ b/src/Components/UpgradeRisksTable/UpgradeRisksTable.cy.js
@@ -147,11 +147,15 @@ describe('successful, only cluster operators', () => {
   });
 
   it('shows 0 alert risks', () => {
-    cy.get('#alerts-label').should('have.text', `0 upgrade risks`);
+    cy.get('#alerts-label')
+      .should('have.text', `0 upgrade risks`)
+      .and('have.class', 'pf-m-green');
   });
 
-  it('does not show icon for alerts', () => {
-    cy.get('.alerts__header').find('.pf-c-icon__content').should('not.exist');
+  it('shows check icon', () => {
+    cy.get('.alerts__header')
+      .find('.pf-c-icon__content')
+      .should('have.class', 'pf-m-success');
   });
 });
 

--- a/src/Components/UpgradeRisksTable/UpgradeRisksTable.js
+++ b/src/Components/UpgradeRisksTable/UpgradeRisksTable.js
@@ -86,14 +86,19 @@ const UpgradeRisksTable = () => {
               />
               <Td>
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                  {!alertsDisabled &&
-                    ALERTS_SEVERITY_ICONS[ // this algorithm helps to decide which icon (the most severe) to show
-                      ALERTS_SEVERITY_ORDER.filter((s) =>
-                        alerts.some(({ severity }) => s === severity)
-                      )[0]
-                    ]}
+                  {alertsDisabled
+                    ? ALERTS_SEVERITY_ICONS['success']
+                    : ALERTS_SEVERITY_ICONS[ // this algorithm helps to decide which icon (the most severe) to show
+                        ALERTS_SEVERITY_ORDER.filter((s) =>
+                          alerts.some(({ severity }) => s === severity)
+                        )[0]
+                      ]}
                   <b>Alerts firing</b>
-                  <Label isCompact id="alerts-label">
+                  <Label
+                    isCompact
+                    id="alerts-label"
+                    color={alertsDisabled ? 'green' : 'grey'}
+                  >
                     {alerts.length} upgrade risks
                   </Label>
                 </Flex>
@@ -125,13 +130,19 @@ const UpgradeRisksTable = () => {
               />
               <Td>
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                  {!conditionsDisabled && (
+                  {conditionsDisabled ? (
+                    ALERTS_SEVERITY_ICONS['success']
+                  ) : (
                     <Icon status="warning">
                       <ExclamationTriangleIcon />
                     </Icon>
                   )}
                   <b>Cluster opertors</b>
-                  <Label isCompact id="operator-conditions-label">
+                  <Label
+                    isCompact
+                    id="operator-conditions-label"
+                    color={conditionsDisabled ? 'green' : 'grey'}
+                  >
                     {conditions.length} upgrade risks
                   </Label>
                 </Flex>


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-85. 
Mocked at https://www.sketch.com/s/c5c07e06-f4a1-4c64-9cdf-8b12d8ac9ad5/a/3ooJoZz.

If there are no alerts or cluster operators, then render the green check mark with green label showing 0 upgrade risks.

![image](https://user-images.githubusercontent.com/31385370/233372529-d1dd4cb1-190d-4dd1-83fe-8211ea3992ce.png)
