### PR TITLE
feat(OCPADVISOR-73): Track clicks on the Upgrade risks tab

### DIFF
--- a/config/overrideChrome.js
+++ b/config/overrideChrome.js
@@ -1,4 +1,7 @@
 export default () => ({
   updateDocumentTitle: () => undefined,
-  isBeta: () => true,
+  isBeta: () => false,
+  analytics: {
+    track: () => fetch('/analytics/track'),
+  },
 });

--- a/cypress/fixtures/api/insights-results-aggregator/v1/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258/upgrade-risks-prediction.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v1/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258/upgrade-risks-prediction.json
@@ -1,6 +1,7 @@
 {
   "status": "ok",
   "upgrade_recommendation": {
+    "upgrade_recommended": false,
     "upgrade_risks_predictors": {
       "alerts": [
         {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -54,7 +54,13 @@ Cypress.Commands.add('mountWithContext', (component, options = {}) => {
   const { path, routerProps = { initialEntries: ['/'] } } = options;
 
   return mount(
-    <FlagProvider>
+    <FlagProvider
+      config={{
+        url: 'http://localhost:8002/feature_flags',
+        clientKey: 'abc',
+        appName: 'abc',
+      }}
+    >
       <Intl>
         <Provider store={getStore()}>
           <MemoryRouter {...routerProps}>

--- a/src/Components/Cluster/Cluster.js
+++ b/src/Components/Cluster/Cluster.js
@@ -9,8 +9,11 @@ import Breadcrumbs from '../Breadcrumbs';
 import ClusterTabs from '../ClusterTabs/ClusterTabs';
 import { Flex, FlexItem, PageSection } from '@patternfly/react-core';
 import { UpgradeRisksAlert } from '../UpgradeRisksAlert';
+import { useUpgradeRisksFeatureFlag } from '../../Utilities/useFeatureFlag';
 
 export const Cluster = ({ cluster, clusterId }) => {
+  const upgradeRisksEnabled = useUpgradeRisksFeatureFlag();
+
   // TODO: make breadcrumbs take display name from GET /cluster/id/info
   return (
     <React.Fragment>
@@ -22,7 +25,7 @@ export const Cluster = ({ cluster, clusterId }) => {
             />
             <ClusterHeader />
           </FlexItem>
-          <UpgradeRisksAlert />
+          {upgradeRisksEnabled && <UpgradeRisksAlert />}
         </Flex>
       </PageHeader>
       <PageSection>

--- a/src/Components/ClusterTabs/ClusterTabs.js
+++ b/src/Components/ClusterTabs/ClusterTabs.js
@@ -1,5 +1,5 @@
 import { Card, CardBody, Tab, Tabs } from '@patternfly/react-core';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 import { useSearchParams } from 'react-router-dom';
@@ -26,6 +26,15 @@ const ClusterTabs = () => {
       : 'recommendations';
   });
 
+  useEffect(() => {
+    if (
+      upgradeRisksEnabled &&
+      searchParams.get('active_tab') === 'upgrade_risks'
+    ) {
+      setActiveKey('upgrade_risks');
+    }
+  }, [upgradeRisksEnabled]);
+
   return (
     <Card isCompact>
       <CardBody>
@@ -43,17 +52,20 @@ const ClusterTabs = () => {
           >
             {activeKey === 'recommendations' && <ClusterRules />}
           </Tab>
-          <Tab
-            eventKey="upgrade_risks"
-            title={intl.formatMessage(messages.upgradeRisks)}
-          >
-            {upgradeRisksEnabled && activeKey === 'upgrade_risks' && (
-              <>
-                <UpgradeRisksTracker />
-                <UpgradeRisksTable />
-              </>
-            )}
-          </Tab>
+          {upgradeRisksEnabled && (
+            <Tab
+              eventKey="upgrade_risks"
+              title={intl.formatMessage(messages.upgradeRisks)}
+              ouiaId="upgrade-risks-tab"
+            >
+              {activeKey === 'upgrade_risks' && (
+                <>
+                  <UpgradeRisksTracker />
+                  <UpgradeRisksTable />
+                </>
+              )}
+            </Tab>
+          )}
         </Tabs>
       </CardBody>
     </Card>

--- a/src/Components/ClusterTabs/ClusterTabs.js
+++ b/src/Components/ClusterTabs/ClusterTabs.js
@@ -8,6 +8,7 @@ import { setSearchParameter } from '../../Utilities/Helpers';
 import { useUpgradeRisksFeatureFlag } from '../../Utilities/useFeatureFlag';
 import ClusterRules from '../ClusterRules/ClusterRules';
 import { UpgradeRisksTable } from '../UpgradeRisksTable';
+import { UpgradeRisksTracker } from '../UpgradeRisksTracker';
 
 const CLUSTER_TABS = ['recommendations', 'upgrade_risks'];
 
@@ -47,7 +48,10 @@ const ClusterTabs = () => {
             title={intl.formatMessage(messages.upgradeRisks)}
           >
             {upgradeRisksEnabled && activeKey === 'upgrade_risks' && (
-              <UpgradeRisksTable />
+              <>
+                <UpgradeRisksTracker />
+                <UpgradeRisksTable />
+              </>
             )}
           </Tab>
         </Tabs>

--- a/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
+++ b/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
@@ -3,14 +3,14 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import messages from '../../Messages';
-import { useGetUpgradeRisksState } from '../../Services/SmartProxy';
+import { useGetUpgradeRisksQuery } from '../../Services/SmartProxy';
 import { strong } from '../../Utilities/Helpers';
 
 const UpgradeRisksAlert = () => {
   const intl = useIntl();
   const { clusterId } = useParams();
   const { isError, isUninitialized, isFetching, isSuccess, data, error } =
-    useGetUpgradeRisksState({ id: clusterId });
+    useGetUpgradeRisksQuery({ id: clusterId });
   const { alerts = [], operator_conditions: conditions = [] } =
     data?.upgrade_recommendation?.upgrade_risks_predictors || {};
 

--- a/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
+++ b/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
@@ -3,14 +3,14 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import messages from '../../Messages';
-import { useGetUpgradeRisksQuery } from '../../Services/SmartProxy';
+import { useGetUpgradeRisksState } from '../../Services/SmartProxy';
 import { strong } from '../../Utilities/Helpers';
 
 const UpgradeRisksAlert = () => {
   const intl = useIntl();
   const { clusterId } = useParams();
   const { isError, isUninitialized, isFetching, isSuccess, data, error } =
-    useGetUpgradeRisksQuery({ id: clusterId });
+    useGetUpgradeRisksState({ id: clusterId });
   const { alerts = [], operator_conditions: conditions = [] } =
     data?.upgrade_recommendation?.upgrade_risks_predictors || {};
 

--- a/src/Components/UpgradeRisksTable/AlertsList.js
+++ b/src/Components/UpgradeRisksTable/AlertsList.js
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-table';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { useGetUpgradeRisksQuery } from '../../Services/SmartProxy';
+import { useGetUpgradeRisksState } from '../../Services/SmartProxy';
 
 export const ALERTS_SEVERITY_ICONS = {
   critical: (
@@ -60,7 +60,7 @@ export const ALERTS_SEVERITY_ORDER = ['critical', 'warning', 'info'];
 
 const AlertsList = () => {
   const { clusterId } = useParams();
-  const { data } = useGetUpgradeRisksQuery({ id: clusterId });
+  const { data } = useGetUpgradeRisksState({ id: clusterId });
   const { alerts = [] } =
     data?.upgrade_recommendation?.upgrade_risks_predictors || {};
 

--- a/src/Components/UpgradeRisksTable/ClusterOperatorsList.js
+++ b/src/Components/UpgradeRisksTable/ClusterOperatorsList.js
@@ -8,13 +8,13 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import { useParams } from 'react-router-dom';
-import { useGetUpgradeRisksQuery } from '../../Services/SmartProxy';
+import { useGetUpgradeRisksState } from '../../Services/SmartProxy';
 import { Flex, Icon } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 
 const ClusterOperatorsList = () => {
   const { clusterId } = useParams();
-  const { data } = useGetUpgradeRisksQuery({ id: clusterId });
+  const { data } = useGetUpgradeRisksState({ id: clusterId });
   const { operator_conditions: conditions = [] } =
     data?.upgrade_recommendation?.upgrade_risks_predictors || {};
 

--- a/src/Components/UpgradeRisksTracker/UpgradeRisksTracker.js
+++ b/src/Components/UpgradeRisksTracker/UpgradeRisksTracker.js
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useGetUpgradeRisksState } from '../../Services/SmartProxy';
 
-const UPGRADE_RISKS_TRACK_EVENT_ID = 'test.foobar';
+const UPGRADE_RISKS_TRACK_EVENT_ID = 'ocp-upgrade-risks-viewed';
 
 const UpgradeRisksTracker = () => {
   const { analytics } = useChrome();

--- a/src/Components/UpgradeRisksTracker/UpgradeRisksTracker.js
+++ b/src/Components/UpgradeRisksTracker/UpgradeRisksTracker.js
@@ -1,0 +1,32 @@
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import get from 'lodash/get';
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useGetUpgradeRisksState } from '../../Services/SmartProxy';
+
+const UPGRADE_RISKS_TRACK_EVENT_ID = 'test.foobar';
+
+const UpgradeRisksTracker = () => {
+  const { analytics } = useChrome();
+  const { clusterId } = useParams();
+  const { isError, isSuccess, data } = useGetUpgradeRisksState({
+    id: clusterId,
+  });
+
+  useEffect(() => {
+    if (isError || isSuccess) {
+      analytics.track(UPGRADE_RISKS_TRACK_EVENT_ID, {
+        cluster_id: clusterId,
+        upgrade_recommended: get(
+          data,
+          'upgrade_recommendation.upgrade_recommended',
+          null
+        ),
+      });
+    }
+  }, [isError, isSuccess]);
+
+  return <></>;
+};
+
+export default UpgradeRisksTracker;

--- a/src/Components/UpgradeRisksTracker/index.js
+++ b/src/Components/UpgradeRisksTracker/index.js
@@ -1,0 +1,1 @@
+export { default as UpgradeRisksTracker } from './UpgradeRisksTracker';

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -45,6 +45,9 @@ export const SmartProxyApi = createApi({
 
 // Export hooks for usage in functional components
 export const {
+  endpoints: {
+    getUpgradeRisks: { useQueryState: useGetUpgradeRisksState },
+  },
   useGetClusterByIdQuery,
   useLazyGetClusterByIdQuery,
   useGetRuleByIdQuery,


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-73.

Send analytics to segment.io (Pendo) when users click on "Upgrade risks" tab or access the page via the `/clusters/%id?active_tab=upgrade_risks` link. UI must include two parameters to the request: cluster_id of the browsed cluster and whether the upgrade is recommended or not. The latter is obtained from the GET /upgrade-risks-prediction endpoint.

## How to test

1. Run PR together with mock service https://github.com/RedHatInsights/ocp-advisor-frontend#using-insights-results-aggregator-mock.
2. Navigate to 00000001-624a-49a5-bab8-4fdc5e51a266 or 00000003-eeee-eeee-eeee-000000000001 clusters and click "Upgrade risks" tab.
3. Check the network request is sent to segment.io (called /t) containing correct properties in its body.
4. Access the same pages with `?active_tab=upgrade_risks` and repeat the previous step.