### PR TITLE
feat(OCPADVISOR-88): Hide upgrade risks for managed clusters

### DIFF
--- a/cypress/fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/info.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/info.json
@@ -1,0 +1,9 @@
+{
+  "cluster": {
+    "cluster_id": "dcb95bbf-8673-4f3a-a63c-12d4a530aa6f",
+    "display_name": "Cluster With Issues",
+    "managed": false,
+    "status": "Stale"
+  },
+  "status": "ok"
+}

--- a/cypress/utils/interceptors.js
+++ b/cypress/utils/interceptors.js
@@ -1,5 +1,6 @@
 import singleClusterPageReport from '../fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/reports-disabled-false.json';
 import upgradeRisksFixtures from '../fixtures/api/insights-results-aggregator/v1/clusters/41c30565-b4c9-49f2-a4ce-3277ad22b258/upgrade-risks-prediction.json';
+import clusterInfoFixtures from '../fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/info.json';
 
 export const clusterReportsInterceptors = {
   successful: () =>
@@ -128,4 +129,29 @@ export const upgradeRisksInterceptors = {
         delay: 420000,
       }
     ),
+};
+
+export const clusterInfoInterceptors = {
+  successful: () =>
+    cy.intercept(
+      'GET',
+      /\/api\/insights-results-aggregator\/v2\/cluster\/.*\/info/,
+      {
+        statusCode: 200,
+        body: clusterInfoFixtures,
+      }
+    ),
+  'successful, managed': () => {
+    const fixtures = clusterInfoFixtures;
+    fixtures.cluster.managed = true;
+
+    return cy.intercept(
+      'GET',
+      /\/api\/insights-results-aggregator\/v2\/cluster\/.*\/info/,
+      {
+        statusCode: 200,
+        body: fixtures,
+      }
+    );
+  },
 };

--- a/src/Components/Cluster/Cluster.js
+++ b/src/Components/Cluster/Cluster.js
@@ -2,6 +2,7 @@ import './_Cluster.scss';
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash/get';
 
 import PageHeader from '@redhat-cloud-services/frontend-components/PageHeader';
 import ClusterHeader from '../ClusterHeader';
@@ -10,9 +11,14 @@ import ClusterTabs from '../ClusterTabs/ClusterTabs';
 import { Flex, FlexItem, PageSection } from '@patternfly/react-core';
 import { UpgradeRisksAlert } from '../UpgradeRisksAlert';
 import { useUpgradeRisksFeatureFlag } from '../../Utilities/useFeatureFlag';
+import { useGetClusterInfoQuery } from '../../Services/SmartProxy';
 
 export const Cluster = ({ cluster, clusterId }) => {
   const upgradeRisksEnabled = useUpgradeRisksFeatureFlag();
+  const clusterInfo = useGetClusterInfoQuery({
+    id: clusterId,
+  });
+  const isManaged = get(clusterInfo, 'data.managed', false);
 
   // TODO: make breadcrumbs take display name from GET /cluster/id/info
   return (
@@ -25,7 +31,7 @@ export const Cluster = ({ cluster, clusterId }) => {
             />
             <ClusterHeader />
           </FlexItem>
-          {upgradeRisksEnabled && <UpgradeRisksAlert />}
+          {upgradeRisksEnabled && !isManaged && <UpgradeRisksAlert />}
         </Flex>
       </PageHeader>
       <PageSection>

--- a/src/Components/ClusterHeader/index.js
+++ b/src/Components/ClusterHeader/index.js
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 
 import {
   useGetClusterByIdQuery,
-  useGetClusterInfoQuery,
+  useGetClusterInfoState,
 } from '../../Services/SmartProxy';
 import { ClusterHeader } from './ClusterHeader';
 
@@ -13,7 +13,7 @@ const ClusterHeaderWrapper = () => {
     id: clusterId,
     includeDisabled: false,
   });
-  const clusterInfo = useGetClusterInfoQuery({
+  const clusterInfo = useGetClusterInfoState({
     id: clusterId,
   });
 

--- a/src/Components/ClusterTabs/ClusterTabs.js
+++ b/src/Components/ClusterTabs/ClusterTabs.js
@@ -1,14 +1,16 @@
 import { Card, CardBody, Tab, Tabs } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
+import get from 'lodash/get';
 
 import { useIntl } from 'react-intl';
-import { useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import messages from '../../Messages';
 import { setSearchParameter } from '../../Utilities/Helpers';
 import { useUpgradeRisksFeatureFlag } from '../../Utilities/useFeatureFlag';
 import ClusterRules from '../ClusterRules/ClusterRules';
 import { UpgradeRisksTable } from '../UpgradeRisksTable';
 import { UpgradeRisksTracker } from '../UpgradeRisksTracker';
+import { useGetClusterInfoState } from '../../Services/SmartProxy';
 
 const CLUSTER_TABS = ['recommendations', 'upgrade_risks'];
 
@@ -16,6 +18,12 @@ const ClusterTabs = () => {
   const intl = useIntl();
   const upgradeRisksEnabled = useUpgradeRisksFeatureFlag();
   const [searchParams] = useSearchParams();
+
+  const { clusterId } = useParams();
+  const clusterInfo = useGetClusterInfoState({
+    id: clusterId,
+  });
+  const isManaged = get(clusterInfo, 'data.managed', false);
 
   const [activeKey, setActiveKey] = useState(() => {
     const activeTab = searchParams.get('active_tab');
@@ -52,7 +60,7 @@ const ClusterTabs = () => {
           >
             {activeKey === 'recommendations' && <ClusterRules />}
           </Tab>
-          {upgradeRisksEnabled && (
+          {upgradeRisksEnabled && !isManaged && (
             <Tab
               eventKey="upgrade_risks"
               title={intl.formatMessage(messages.upgradeRisks)}

--- a/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
+++ b/src/Components/UpgradeRisksAlert/UpgradeRisksAlert.js
@@ -24,6 +24,7 @@ const UpgradeRisksAlert = () => {
       variant="warning"
       isInline
       title={intl.formatMessage(messages.resolveUpgradeRisks)}
+      ouiaId="upgrade-risks-alert"
     >
       {intl.formatMessage(messages.resolveUpgradeRisksDesc, { strong })}
     </Alert>
@@ -32,12 +33,14 @@ const UpgradeRisksAlert = () => {
       variant="success"
       isInline
       title={intl.formatMessage(messages.noKnownUpgradeRisks)}
+      ouiaId="upgrade-risks-alert"
     />
   ) : isError && error.status === 404 ? (
     <Alert
       variant="warning"
       isInline
       title={intl.formatMessage(messages.upgradeRisksNotCurrentlyAvailable)}
+      ouiaId="upgrade-risks-alert"
     >
       {intl.formatMessage(messages.upgradeRisksNotAvailableDesc)}
     </Alert>

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -47,6 +47,7 @@ export const SmartProxyApi = createApi({
 export const {
   endpoints: {
     getUpgradeRisks: { useQueryState: useGetUpgradeRisksState },
+    getClusterInfo: { useQueryState: useGetClusterInfoState },
   },
   useGetClusterByIdQuery,
   useLazyGetClusterByIdQuery,


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-88.

This makes the cluster details page hide all the upgrade risks-related features for managed clusters. The info about the cluster status is already available from the `GET /%clusterId/info` endpoint.

## How to test

TBA