### PR TITLE
fix(OCPADVISOR-82): Fix "affected clusters" link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@patternfly/react-core": "^4.276.6",
         "@patternfly/react-table": "^4.112.39",
         "@redhat-cloud-services/frontend-components": "^3.9.34",
-        "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.7",
+        "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.8",
         "@redhat-cloud-services/frontend-components-charts": "^3.2.5",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.14",
         "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
@@ -3804,9 +3804,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-advisor-components": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.7.tgz",
-      "integrity": "sha512-7+NSz7GA4t+5o2s3t1nAIQPeB0wAA2LWZ5hMWqjZMcJlKoNZRZ4kJUBhm/JICTWr+OjXSvM0+6mePYS062na2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.8.tgz",
+      "integrity": "sha512-hELs7KZ01myFjb66zlreL8/xbrIiF1Yjn+drCRClxuEa6jM4PO4soO5wyGh4pNyh0ClFxHSTbl3F9cSg0zTxHA==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^3.9.12",
         "dot": "^1.1.3",
@@ -28136,9 +28136,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-advisor-components": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.7.tgz",
-      "integrity": "sha512-7+NSz7GA4t+5o2s3t1nAIQPeB0wAA2LWZ5hMWqjZMcJlKoNZRZ4kJUBhm/JICTWr+OjXSvM0+6mePYS062na2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.8.tgz",
+      "integrity": "sha512-hELs7KZ01myFjb66zlreL8/xbrIiF1Yjn+drCRClxuEa6jM4PO4soO5wyGh4pNyh0ClFxHSTbl3F9cSg0zTxHA==",
       "requires": {
         "@redhat-cloud-services/frontend-components": "^3.9.12",
         "dot": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@patternfly/react-core": "^4.276.6",
     "@patternfly/react-table": "^4.112.39",
     "@redhat-cloud-services/frontend-components": "^3.9.34",
-    "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.7",
+    "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.8",
     "@redhat-cloud-services/frontend-components-charts": "^3.2.5",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.14",
     "@redhat-cloud-services/frontend-components-translations": "^3.2.4",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPADVISOR-82.

This upgrade the advisor-components dependency where the links were updated to accomodate upgrade of react-router-dom to v6 and using the correct links format.

## How to test

1. With this PR, run `npm run start:proxy:beta`
2. Navigate to https://stage.foo.redhat.com:1337/preview/openshift/insights/advisor/recommendations
3. Expand content for any of the recommendation that hits at least 1 cluster
4. Click on "View affected clusters" link below. Check that you are redirect to the recommendation details page.