### PR TITLE
fix(OCPADVISOR-89): Fix active tab handling

### DIFF
--- a/src/Components/ClusterTabs/ClusterTabs.js
+++ b/src/Components/ClusterTabs/ClusterTabs.js
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 import { useParams, useSearchParams } from 'react-router-dom';
 import messages from '../../Messages';
 import { setSearchParameter } from '../../Utilities/Helpers';
-import { useUpgradeRisksFeatureFlag } from '../../Utilities/useFeatureFlag';
 import ClusterRules from '../ClusterRules/ClusterRules';
 import { UpgradeRisksTable } from '../UpgradeRisksTable';
 import { UpgradeRisksTracker } from '../UpgradeRisksTracker';
@@ -15,28 +14,19 @@ const CLUSTER_TABS = ['recommendations', 'upgrade_risks'];
 
 const ClusterTabs = () => {
   const intl = useIntl();
-  const upgradeRisksEnabled = useUpgradeRisksFeatureFlag();
   const [searchParams] = useSearchParams();
-
   const { clusterId } = useParams();
-  const areUpgradeRisksEnabled = useUpgradeRisksFeature(clusterId);
+  const upgradeRisksEnabled = useUpgradeRisksFeature(clusterId);
 
-  const [activeKey, setActiveKey] = useState(() => {
-    const activeTab = searchParams.get('active_tab');
-    return areUpgradeRisksEnabled
-      ? CLUSTER_TABS.includes(activeTab)
-        ? activeTab
-        : 'recommendations'
-      : 'recommendations';
-  });
+  const [activeKey, setActiveKey] = useState('recommendations');
 
   useEffect(() => {
-    if (
-      areUpgradeRisksEnabled &&
-      searchParams.get('active_tab') === 'upgrade_risks'
-    ) {
-      setActiveKey('upgrade_risks');
-    }
+    const tabKey = searchParams.get('active_tab');
+    setActiveKey(
+      upgradeRisksEnabled && CLUSTER_TABS.includes(tabKey)
+        ? tabKey
+        : 'recommendations'
+    );
   }, [upgradeRisksEnabled]);
 
   return (
@@ -57,7 +47,7 @@ const ClusterTabs = () => {
           >
             {activeKey === 'recommendations' && <ClusterRules />}
           </Tab>
-          {areUpgradeRisksEnabled && (
+          {upgradeRisksEnabled && (
             <Tab
               eventKey="upgrade_risks"
               title={intl.formatMessage(messages.upgradeRisks)}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPADVISOR-89.

This fixes incorrect active tab handling provided by `active_tab` URL parameter.

## How to test

1. Deploy with `npm run start:proxy:beta`,
2. Navigate to any cluster (cluster details page), e.g. https://stage.foo.redhat.com:1337/beta/openshift/insights/advisor/clusters/bc960900-da34-11ed-b4ef-5405db17362c (under `insights-qa`),
3. Click on the upgrade risks tab and refresh the page,
4. Check that 1) the refreshed page keeps upgrade risks tab open, 2) URL contains `active_tab=upgrade_risks`,
5. Click on the recommendations page and refresh the page,
6. Check that 1) the refreshed page keeps recommendations tab open, 2) URL contains `active_tab=recommendations`.