### PR TITLE
fix(RHCLOUD-27717): Exclude react-redux from shared dependencies

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -38,6 +38,7 @@ plugins.push(
           'react-router-dom': { singleton: true, requiredVersion: '*' },
         },
       ],
+      exclude: ['react-redux'],
     }
   )
 );

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -21,6 +21,7 @@ plugins.push(
           'react-router-dom': { singleton: true, requiredVersion: '*' },
         },
       ],
+      exclude: ['react-redux'],
     }
   )
 );


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHCLOUD-27717.