### PR TITLE
feat(Filtering): Add Best Practice category

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -2,6 +2,7 @@
   "actions": "Actions",
   "affectedClusters": "Affected clusters",
   "all": "All",
+  "bestPractice": "Best Practice",
   "cancel": "Cancel",
   "category": "Category",
   "clusterDetailsRedirect": "View cluster details",

--- a/cypress/fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/reports-disabled-false.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/cluster/dcb95bbf-8673-4f3a-a63c-12d4a530aa6f/reports-disabled-false.json
@@ -54,7 +54,11 @@
           },
           "type": "rule"
         },
-        "tags": ["security", "service_availability"]
+        "tags": [
+          "security",
+          "service_availability",
+          "best_practice"
+        ]
       },
       {
         "rule_id": "external.rules.rule_n_one|ERROR_KEY_N2",
@@ -104,7 +108,9 @@
           },
           "type": "rule"
         },
-        "tags": ["service_availability"]
+        "tags": [
+          "service_availability"
+        ]
       },
       {
         "rule_id": "external.rules.rule_n_one|ERROR_KEY_N3",
@@ -154,7 +160,10 @@
           },
           "type": "rule"
         },
-        "tags": ["performance", "service_availability"]
+        "tags": [
+          "performance",
+          "service_availability"
+        ]
       },
       {
         "rule_id": "external.rules.rule_n_one|ERROR_KEY_N4",
@@ -204,7 +213,11 @@
           },
           "type": "rule"
         },
-        "tags": ["security", "service_availability", "fault_tolerance"]
+        "tags": [
+          "security",
+          "service_availability",
+          "fault_tolerance"
+        ]
       },
       {
         "rule_id": "external.rules.rule_n_one|ERROR_KEY_N5",
@@ -254,7 +267,10 @@
           },
           "type": "rule"
         },
-        "tags": ["security", "service_availability"]
+        "tags": [
+          "security",
+          "service_availability"
+        ]
       },
       {
         "rule_id": "external.rules.rule_n_one|ERROR_KEY_N6",
@@ -303,7 +319,9 @@
           },
           "type": "rule"
         },
-        "tags": ["security"]
+        "tags": [
+          "security"
+        ]
       }
     ]
   },

--- a/cypress/fixtures/api/insights-results-aggregator/v2/rule.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/rule.json
@@ -8,7 +8,12 @@
       "total_risk": 2,
       "impact": 1,
       "likelihood": 4,
-      "tags": ["openshift", "etcd", "performance"],
+      "tags": [
+        "openshift",
+        "etcd",
+        "performance",
+        "best_practice"
+      ],
       "disabled": false,
       "risk_of_change": 0,
       "impacted_clusters_count": 1,
@@ -41,7 +46,11 @@
       "total_risk": 2,
       "impact": 2,
       "likelihood": 3,
-      "tags": ["openshift", "configuration", "service_availability"],
+      "tags": [
+        "openshift",
+        "configuration",
+        "service_availability"
+      ],
       "disabled": false,
       "risk_of_change": 0,
       "impacted_clusters_count": 0,
@@ -55,7 +64,12 @@
       "total_risk": 2,
       "impact": 1,
       "likelihood": 4,
-      "tags": ["service_availability", "vsphere", "disk", "security"],
+      "tags": [
+        "service_availability",
+        "vsphere",
+        "disk",
+        "security"
+      ],
       "disabled": false,
       "risk_of_change": 0,
       "impacted_clusters_count": 0,
@@ -69,7 +83,11 @@
       "total_risk": 2,
       "impact": 2,
       "likelihood": 3,
-      "tags": ["openshift", "performance", "osd_customer"],
+      "tags": [
+        "openshift",
+        "performance",
+        "osd_customer"
+      ],
       "disabled": false,
       "risk_of_change": 0,
       "impacted_clusters_count": 0,
@@ -83,7 +101,11 @@
       "total_risk": 3,
       "impact": 2,
       "likelihood": 2,
-      "tags": ["service_availability", "openshift", "operator"],
+      "tags": [
+        "service_availability",
+        "openshift",
+        "operator"
+      ],
       "disabled": false,
       "risk_of_change": 0,
       "impacted_clusters_count": 100,
@@ -97,7 +119,10 @@
       "total_risk": 4,
       "impact": 1,
       "likelihood": 2,
-      "tags": ["openshift", "service_availability"],
+      "tags": [
+        "openshift",
+        "service_availability"
+      ],
       "disabled": false,
       "risk_of_change": 0,
       "impacted_clusters_count": 2003,
@@ -111,7 +136,10 @@
       "total_risk": 2,
       "impact": 1,
       "likelihood": 4,
-      "tags": ["openshift", "service_availability"],
+      "tags": [
+        "openshift",
+        "service_availability"
+      ],
       "disabled": true,
       "risk_of_change": 0,
       "impacted_clusters_count": 2,
@@ -125,7 +153,10 @@
       "total_risk": 1,
       "impact": 1,
       "likelihood": 1,
-      "tags": ["openshift", "service_availability"],
+      "tags": [
+        "openshift",
+        "service_availability"
+      ],
       "disabled": true,
       "risk_of_change": 0,
       "impacted_clusters_count": 0,

--- a/cypress/utils/globals.js
+++ b/cypress/utils/globals.js
@@ -6,6 +6,7 @@ const CATEGORIES = {
   Security: ['security'],
   'Fault Tolerance': ['fault_tolerance'],
   Performance: ['performance'],
+  'Best Practice': ['best_practice'],
 };
 
 const SORTING_ORDERS = ['ascending', 'descending'];

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -46,6 +46,7 @@ export const RULE_CATEGORIES = {
   performance: 2,
   fault_tolerance: 3,
   security: 4,
+  best_practice: 5,
 };
 export const FILTER_CATEGORIES = {
   total_risk: {
@@ -140,6 +141,13 @@ export const FILTER_CATEGORIES = {
       {
         label: intlHelper(intl.formatMessage(messages.security), intlSettings),
         value: `${RULE_CATEGORIES.security}`,
+      },
+      {
+        label: intlHelper(
+          intl.formatMessage(messages.bestPractice),
+          intlSettings
+        ),
+        value: `${RULE_CATEGORIES.best_practice}`,
       },
     ],
   },

--- a/src/Components/Labels/CategoryLabel.js
+++ b/src/Components/Labels/CategoryLabel.js
@@ -8,6 +8,7 @@ import LockIcon from '@patternfly/react-icons/dist/esm/icons/lock-icon';
 import PortIcon from '@patternfly/react-icons/dist/esm/icons/port-icon';
 import AutomationIcon from '@patternfly/react-icons/dist/esm/icons/automation-icon';
 import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-icon';
+import OptimizeIcon from '@patternfly/react-icons/dist/esm/icons/optimize-icon';
 
 import messages from '../../Messages';
 import { RULE_CATEGORIES } from '../../AppConstants';
@@ -17,6 +18,7 @@ const CATEGORY_ICONS = {
   service_availability: <AutomationIcon />,
   performance: <PortIcon />,
   fault_tolerance: <SyncAltIcon />,
+  best_practice: <OptimizeIcon />,
 };
 
 export const extractCategories = (tags) =>

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -108,23 +108,28 @@ export default defineMessages({
   },
   serviceAvailability: {
     id: 'serviceAvailability',
-    description: 'Filter value',
+    description: 'Category Filter value',
     defaultMessage: 'Service Availability',
   },
   performance: {
     id: 'performance',
-    description: 'Filter value',
+    description: 'Category Filter value',
     defaultMessage: 'Performance',
   },
   faultTolerance: {
     id: 'faultTolerance',
-    description: 'Filter value',
+    description: 'Category Filter value',
     defaultMessage: 'Fault Tolerance',
   },
   security: {
     id: 'security',
-    description: 'Filter value',
+    description: 'Category Filter value',
     defaultMessage: 'Security',
+  },
+  bestPractice: {
+    id: 'bestPractice',
+    description: 'Category Filter value',
+    defaultMessage: 'Best Practice',
   },
   enabled: {
     id: 'enabled',


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OCPADVISOR-111.

This adds one new category to the Category filter: users are now able to filter rules by the Best Practice category.

## How to test

Go to /openshift/insights/advisor/recommendations, check that you are able to filter rules by Best Practice category. Do the same on any cluster details page. There are currently no recommendations that have this category, so you are supposed to see an empty list.

## Screenshots

/recommendations:

https://github.com/RedHatInsights/ocp-advisor-frontend/assets/31385370/8d8ef14d-929e-4757-b9f5-bcae73536765

/clusters/%id:

https://github.com/RedHatInsights/ocp-advisor-frontend/assets/31385370/afdec0dd-f42a-4417-819e-c792f0c89ecb


