### PR TITLE
fix(AffectedClustersTable): Version column wider

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -282,7 +282,7 @@ export const AFFECTED_CLUSTERS_COLUMNS = [
   },
   {
     title: intl.formatMessage(messages.version),
-    transforms: [sortable, fitContent],
+    transforms: [sortable],
   },
   {
     title: intl.formatMessage(messages.lastSeen),


### PR DESCRIPTION
[OCPADVISOR-102](https://issues.redhat.com/browse/OCPADVISOR-102)

Open OCP Advisor > Recommendations > Select a recommendation

The version column is now wider.

Thanks to Georgii for the hint in the ticket, was a quick fix.

Before: 
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/20592948/d637184b-2baf-4530-8ee4-4fc1595b7eb0)

After:
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/20592948/cb49b018-6f57-42a9-9a54-a9c246480db4)