### PR TITLE
feat(OCPADVISOR-124): workloads feature flag

### DIFF
--- a/src/Utilities/useFeatureFlag.js
+++ b/src/Utilities/useFeatureFlag.js
@@ -12,9 +12,18 @@ export default useFeatureFlag;
 export const UPDATE_RISKS_ENABLE_FLAG =
   'ocp-advisor.upgrade-risks.enable-in-stable';
 
+export const WORKLOADS_ENABLE_FLAG = 'ocp-advisor-ui-workloads';
+
 export const useUpdateRisksFeatureFlag = () => {
   const updateRisksEnabled = useFeatureFlag(UPDATE_RISKS_ENABLE_FLAG);
   const chrome = useChrome();
 
   return chrome.isBeta() || updateRisksEnabled;
+};
+
+export const useWorkloadsFeatureFlag = () => {
+  const workloadsEnabled = useFeatureFlag(WORKLOADS_ENABLE_FLAG);
+  const chrome = useChrome();
+
+  return chrome.isBeta() || workloadsEnabled;
 };


### PR DESCRIPTION
Add a new feature flag to the unleash that will allow us to develop workloads

To test run "npm run start:proxy:beta"

add to the Recstable or other component
const workloadsEnabled = useFeatureFlag(WORKLOADS_ENABLE_FLAG);
console.log(workloadsEnabled, 'FLAG');
Import required functions and stuff
Check that the console log prints TRUE