### PR TITLE
feat(OCPADVISOR-143): Connect workloads to mocked API

### DIFF
--- a/src/Components/HighestSeverityBadge/HighestSeverityBadge.js
+++ b/src/Components/HighestSeverityBadge/HighestSeverityBadge.js
@@ -4,13 +4,7 @@ import { TooltipPosition } from '@patternfly/react-core/dist/js/components/Toolt
 import InsightsLabel from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import PropTypes from 'prop-types';
 
-export const HighestSeverityBadge = ({ severities }) => {
-  let highestSeverity = 0;
-
-  Object.keys(severities).forEach((severityType) =>
-    severities[severityType] > 0 ? (highestSeverity = severityType) : null
-  );
-
+export const HighestSeverityBadge = ({ highestSeverity, severities }) => {
   const severityTypeToText = (value) => {
     value = parseInt(value);
     if (value === 1) {
@@ -44,5 +38,6 @@ export const HighestSeverityBadge = ({ severities }) => {
 };
 
 HighestSeverityBadge.propTypes = {
-  severities: PropTypes.arrayOf(PropTypes.number),
+  severities: PropTypes.object,
+  highestSeverity: PropTypes.number,
 };

--- a/src/Components/WorkloadsListTable/index.js
+++ b/src/Components/WorkloadsListTable/index.js
@@ -1,14 +1,11 @@
-//Wrapper for API connection
 import React from 'react';
-
-/* import { useGetClustersQuery } from '../../Services/SmartProxy'; */
+import { useGetWorkloadsQuery } from '../../Services/SmartProxy';
 import { WorkloadsListTable } from './WorkloadsListTable';
 
 const WorkloadsListTableWrapper = () => {
-  //Will be a workloads query when we connect it to the API
-  /* const query = useGetClustersQuery(); */
+  const query = useGetWorkloadsQuery();
 
-  return <WorkloadsListTable /* query={query} */ />;
+  return <WorkloadsListTable query={query} />;
 };
 
 export default WorkloadsListTableWrapper;

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -40,6 +40,13 @@ export const SmartProxyApi = createApi({
     getUpdateRisks: builder.query({
       query: ({ id }) => `v2/cluster/${id}/upgrade-risks-prediction`,
     }),
+    getWorkloads: builder.query({
+      query: () => `v2/namespaces/dvo`,
+    }),
+    getWorkloadById: builder.query({
+      query: ({ namespace_uuid, cluster_uuid }) =>
+        `v2/namespaces/dvo/${namespace_uuid}/cluster/${cluster_uuid}`,
+    }),
   }),
 });
 
@@ -58,4 +65,6 @@ export const {
   useGetClustersQuery,
   useGetClusterInfoQuery,
   useGetUpdateRisksQuery,
+  useGetWorkloadsQuery,
+  useLazyGetWorkloadByIdQuery,
 } = SmartProxyApi;


### PR DESCRIPTION
[OCPADVISOR-143](https://issues.redhat.com/browse/OCPADVISOR-143)

How to setup mock api:
1. Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock)
2. `make build` (takes a few minutes for me, coffee time ☕)
2.1. can speed it up with `make build -j 4` to run multiple jobs at once
3. `make run`
4. Test the mocked api `curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo`
5. Run the app `MOCK=true npm run start:proxy:beta`
6. Workloads should load mocked data

~~Severities are missing, so they're still hardcoded.
Highest Severity is set to 5, but such level doesn't exist?~~ Fixed by the backend folks
Workload details route has to be changed, because the api needs both `cluster_uuid` and `namespace_uuid`

~~Update: Waiting for the mock api to change~~
Ready