### PR TITLE
feat(OCPADVISOR-138): workloads table empty state

### DIFF
--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -18,6 +18,7 @@ import { InProgressIcon } from '@patternfly/react-icons/dist/esm/icons/in-progre
 import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 import { global_info_color_100 as globalInfoColor100 } from '@patternfly/react-tokens/dist/js/global_info_color_100.js';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import WrenchIcon from '@patternfly/react-icons/dist/js/icons/wrench-icon';
 
 import DefaultErrorMessage from '@redhat-cloud-services/frontend-components/ErrorState/DefaultErrorMessage';
 
@@ -212,6 +213,66 @@ const UpdateRisksNotAvailable = () => {
   );
 };
 
+const NoRecsForWorkloads = () => {
+  return (
+    <MessageState
+      icon={CheckCircleIcon}
+      iconStyle={{
+        color: globalSuccessColor100.value,
+      }}
+      title="No workload recommendations"
+      text={
+        <>
+          <p>
+            There are no workload-related recommendations for your clusters.
+            This page only shows workloads if there are recommendations
+            available.
+          </p>
+          <Button
+            variant="primary"
+            className="pf-v5-u-mt-xl"
+            onClick={() => history.back()}
+          >
+            Return to previous page
+          </Button>
+        </>
+      }
+    />
+  );
+};
+
+const NoWorkloadsAvailable = () => {
+  return (
+    <MessageState
+      icon={WrenchIcon}
+      title="Workloads data unavailable"
+      text={
+        <>
+          <p>
+            Verify that your clusters are connected and sending data to Red Hat,
+            and that the Deployment Validation Operator is installed and
+            configured.
+          </p>
+          <Button
+            variant="primary"
+            className="pf-v5-u-mt-xl"
+            onClick={() => history.back()}
+          >
+            Return to previous page
+          </Button>
+          <br />
+          <a
+            className="pf-v5-u-display-inline-block pf-v5-u-mt-xl"
+            href="https://docs.openshift.com/container-platform/latest/support/getting-support.html"
+          >
+            View documentation
+          </a>
+        </>
+      }
+    />
+  );
+};
+
 export {
   ErrorState,
   NoAffectedClusters,
@@ -224,4 +285,6 @@ export {
   NoRecsAffecting,
   NoUpdateRisks,
   UpdateRisksNotAvailable,
+  NoRecsForWorkloads,
+  NoWorkloadsAvailable,
 };

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -39,13 +39,26 @@ import {
   paramParser,
   updateSearchParams,
 } from '../Common/Tables';
-import { ErrorState, NoMatchingClusters } from '../MessageState/EmptyStates';
+import {
+  ErrorState,
+  NoMatchingClusters,
+  NoRecsForWorkloads,
+  NoWorkloadsAvailable,
+} from '../MessageState/EmptyStates';
 import Loading from '../Loading/Loading';
 import ShieldSet from '../ShieldSet';
 import { noFiltersApplied } from '../../Utilities/Workloads';
 
 const WorkloadsListTable = ({
-  query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
+  query: {
+    isError,
+    error,
+    isUninitialized,
+    isFetching,
+    isSuccess,
+    data,
+    refetch,
+  },
 }) => {
   const dispatch = useDispatch();
   const filters = useSelector(({ filters }) => filters.workloadsListState);
@@ -75,6 +88,7 @@ const WorkloadsListTable = ({
   useEffect(() => {
     setFilteredRows(buildFilteredRows(workloads));
   }, [
+    data,
     filters.namespace_name,
     filters.cluster_name,
     filters.general_severity,
@@ -278,7 +292,11 @@ const WorkloadsListTable = ({
     updateFilters({ ...filters, sortIndex: index, sortDirection: direction });
   };
 
-  return (
+  return isError && error.status === 404 ? (
+    <NoWorkloadsAvailable />
+  ) : isSuccess && workloads.length === 0 ? (
+    <NoRecsForWorkloads />
+  ) : (
     <div id="workloads-list-table">
       <PrimaryToolbar
         pagination={{


### PR DESCRIPTION
[OCPADVISOR-138](https://issues.redhat.com/browse/OCPADVISOR-138)

### No workload recommendations:
When you recieve an empty array of workloads
[Mock](https://www.sketch.com/s/46f6d8e3-a4d0-4249-9d57-e6a79b518a6d/a/ZVg3O2J)

![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/20592948/842fcf1b-9ef9-4880-84bd-d8e1facdd7d7)

#### How to test:
in `src/Components/WorkloadsListTable/index.js`
replace query with
```js
  const query = {
    data: { workloads: [] },
    isSuccess: true,
    isError: false,
  };
```

### Workloads data unavailable
When request returns 404
[Mock](https://www.sketch.com/s/46f6d8e3-a4d0-4249-9d57-e6a79b518a6d/a/zyQgxvy)

![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/20592948/97fbb6e4-171c-4ccd-8cce-6afcf0114723)

#### How to test:
in `src/Components/WorkloadsListTable/index.js`
replace query with
```js
  const query = {
    data: { workloads: [] },
    isSuccess: false,
    isError: true,
    error: { status: 404 },
  };
```