### PR TITLE
feat(ocpadvisor-123): functional filters with mockdata

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -445,4 +445,15 @@ export const WORKLOADS_TABLE_FILTER_CATEGORIES = {
       { label: 'Low', text: 'Low', value: 'low' },
     ],
   },
+  general_severity: {
+    type: 'checkbox',
+    title: 'General severity',
+    urlParam: 'general_severity',
+    values: [
+      { label: 'Critical', text: 'Critical', value: 'critical' },
+      { label: 'Important', text: 'Important', value: 'important' },
+      { label: 'Moderate', text: 'Moderate', value: 'moderate' },
+      { label: 'Low', text: 'Low', value: 'low' },
+    ],
+  },
 };

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -434,17 +434,6 @@ export const WORKLOADS_TABLE_CELL_OBJECTS = 3;
 export const WORKLOADS_TABLE_CELL_LAST_SEEN = 4;
 
 export const WORKLOADS_TABLE_FILTER_CATEGORIES = {
-  highest_severity: {
-    type: 'checkbox',
-    title: 'Highest severity',
-    urlParam: 'highest_severity',
-    values: [
-      { label: 'Critical', text: 'Critical', value: 'critical' },
-      { label: 'Important', text: 'Important', value: 'important' },
-      { label: 'Moderate', text: 'Moderate', value: 'moderate' },
-      { label: 'Low', text: 'Low', value: 'low' },
-    ],
-  },
   general_severity: {
     type: 'checkbox',
     title: 'General severity',

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -7,6 +7,10 @@ import {
   FILTER_CATEGORIES,
   RULE_CATEGORIES,
 } from '../../AppConstants';
+import {
+  hasAnyValueGreaterThanZero,
+  remappingSeverity,
+} from '../../Utilities/Workloads';
 
 export const passFilters = (rule, filters) =>
   Object.entries(filters).every(([filterKey, filterValue]) => {
@@ -275,48 +279,6 @@ export const addFilterParam = (currentFilters, updateFilters, param, values) =>
         ...{ [param]: values },
       })
     : removeFilterParam(currentFilters, updateFilters, param);
-
-export const severityTypeToText = (value) => {
-  value = parseInt(value);
-  if (value === 1) {
-    return 'Low';
-  } else if (value === 2) {
-    return 'Moderate';
-  } else if (value === 3) {
-    return 'Important';
-  } else {
-    return 'Critical';
-  }
-};
-
-export const remappingSeverity = (obj, mode) => {
-  const mapping = {
-    1: 'low',
-    2: 'moderate',
-    3: 'important',
-    4: 'critical',
-  };
-  let updatedObj = {};
-
-  if (mode === 'general') {
-    for (const key in obj) {
-      if (key in mapping) {
-        updatedObj[mapping[key]] = obj[key];
-      }
-    }
-  } else {
-    updatedObj = mapping[obj];
-  }
-  return updatedObj;
-};
-
-function hasAnyValueGreaterThanZero(obj, stringsToCheck) {
-  for (const key of stringsToCheck) {
-    if (obj[key] > 0) {
-      return true; // Return true if any matching string has a value greater than 0
-    }
-  }
-}
 
 export const passFilterWorkloads = (workloads, filters) => {
   const generalSeverityRemapped = remappingSeverity(

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -275,3 +275,68 @@ export const addFilterParam = (currentFilters, updateFilters, param, values) =>
         ...{ [param]: values },
       })
     : removeFilterParam(currentFilters, updateFilters, param);
+
+export const severityTypeToText = (value) => {
+  value = parseInt(value);
+  if (value === 1) {
+    return 'Low';
+  } else if (value === 2) {
+    return 'Moderate';
+  } else if (value === 3) {
+    return 'Important';
+  } else {
+    return 'Critical';
+  }
+};
+
+export const remappingSeverity = (obj) => {
+  const mapping = {
+    1: 'low',
+    2: 'moderate',
+    3: 'important',
+    4: 'critical',
+  };
+
+  const updatedObj = {};
+
+  for (const key in obj) {
+    if (key in mapping) {
+      updatedObj[mapping[key]] = obj[key];
+    }
+  }
+
+  return updatedObj;
+};
+
+function hasAnyValueGreaterThanZero(obj, stringsToCheck) {
+  for (const key of stringsToCheck) {
+    if (obj[key] > 0) {
+      return true; // Return true if any matching string has a value greater than 0
+    }
+  }
+}
+
+export const passFilterWorkloads = (workloads, filters) => {
+  const severityRemapped = remappingSeverity(
+    workloads.metadata.hits_by_severity
+  );
+  return Object.entries(filters).every(([filterKey, filterValue]) => {
+    switch (filterKey) {
+      case 'cluster_name':
+        return workloads.cluster.display_name
+          .toLowerCase()
+          .includes(filterValue.toLowerCase());
+      case 'namespace_name':
+        return workloads.namespace.name
+          .toLowerCase()
+          .includes(filterValue.toLowerCase());
+      case 'highest_severity':
+        return (
+          filterValue.length === 0 ||
+          hasAnyValueGreaterThanZero(severityRemapped, filters.highest_severity)
+        );
+      default:
+        return true;
+    }
+  });
+};

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -285,10 +285,6 @@ export const passFilterWorkloads = (workloads, filters) => {
     workloads.metadata.hits_by_severity,
     'general'
   );
-  const highestSeverityRemapped = remappingSeverity(
-    workloads.metadata.highest_severity,
-    'highest'
-  );
   return Object.entries(filters).every(([filterKey, filterValue]) => {
     switch (filterKey) {
       case 'cluster_name':
@@ -306,11 +302,6 @@ export const passFilterWorkloads = (workloads, filters) => {
             generalSeverityRemapped,
             filters.general_severity
           )
-        );
-      case 'highest_severity':
-        return (
-          filterValue.length === 0 ||
-          filterValue.includes(highestSeverityRemapped)
         );
       default:
         return true;

--- a/src/Components/HighestSeverityBadge/HighestSeverityBadge.js
+++ b/src/Components/HighestSeverityBadge/HighestSeverityBadge.js
@@ -3,21 +3,9 @@ import { Tooltip } from '@patternfly/react-core';
 import { TooltipPosition } from '@patternfly/react-core/dist/js/components/Tooltip';
 import InsightsLabel from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import PropTypes from 'prop-types';
+import { severityTypeToText } from '../Common/Tables';
 
 export const HighestSeverityBadge = ({ highestSeverity, severities }) => {
-  const severityTypeToText = (value) => {
-    value = parseInt(value);
-    if (value === 1) {
-      return 'Low';
-    } else if (value === 2) {
-      return 'Moderate';
-    } else if (value === 3) {
-      return 'Important';
-    } else {
-      return 'Critical';
-    }
-  };
-
   const severitiesToDisplay = Object.keys(severities)
     .map((severityType) => {
       return severities[severityType] > 0 ? (

--- a/src/Components/HighestSeverityBadge/HighestSeverityBadge.js
+++ b/src/Components/HighestSeverityBadge/HighestSeverityBadge.js
@@ -3,7 +3,7 @@ import { Tooltip } from '@patternfly/react-core';
 import { TooltipPosition } from '@patternfly/react-core/dist/js/components/Tooltip';
 import InsightsLabel from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import PropTypes from 'prop-types';
-import { severityTypeToText } from '../Common/Tables';
+import { severityTypeToText } from '../../Utilities/Workloads';
 
 export const HighestSeverityBadge = ({ highestSeverity, severities }) => {
   const severitiesToDisplay = Object.keys(severities)

--- a/src/Components/ShieldSet.js
+++ b/src/Components/ShieldSet.js
@@ -8,7 +8,8 @@ import { SEVERITY_OPTIONS, remappingSeverity } from '../Utilities/Workloads';
 const ShieldSet = (hits_by_severity) => {
   const DISABLED_COLOR = 'var(--pf-global--disabled-color--200)';
   const severitiesRemapped = remappingSeverity(
-    hits_by_severity.hits_by_severity
+    hits_by_severity.hits_by_severity,
+    'label'
   );
   return (
     <div className="shield-set">

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -99,10 +99,6 @@ const WorkloadsListTable = ({
           item.metadata.recommendations,
           <span key={index}>
             <ShieldSet hits_by_severity={item.metadata.hits_by_severity} />
-            {/* <HighestSeverityBadge
-              highestSeverity={item.metadata.highest_severity}
-              severities={item.metadata.hits_by_severity}
-            /> */}
           </span>,
           item.metadata.objects,
           <span key={index}>

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -47,6 +47,9 @@ const WorkloadsListTable = ({
   const [rows, setRows] = useState([]);
   const [filteredRows, setFilteredRows] = useState([]);
   const [rowsFiltered, setRowsFiltered] = useState(false);
+  const [filtersApplied] = useState(
+    filters === WORKLOADS_TABLE_INITIAL_STATE ? false : true
+  );
   const updateFilters = (payload) =>
     dispatch(updateWorkloadsListFilters(payload));
   const removeFilterParam = (param) =>
@@ -69,6 +72,7 @@ const WorkloadsListTable = ({
   }, [
     filters.namespace_name,
     filters.cluster_name,
+    filters.general_severity,
     filters.highest_severity,
     filters.sortDirection,
     filters.sortIndex,
@@ -148,10 +152,24 @@ const WorkloadsListTable = ({
         placeholder: 'Filter by highest severity',
       },
     },
+    {
+      label: 'General severity',
+      type: conditionalFilterType.checkbox,
+      id: WORKLOADS_TABLE_FILTER_CATEGORIES.general_severity.urlParam,
+      value: `checkbox-${WORKLOADS_TABLE_FILTER_CATEGORIES.general_severity.urlParam}`,
+      filterValues: {
+        key: `${WORKLOADS_TABLE_FILTER_CATEGORIES.general_severity.urlParam}-filter`,
+        onChange: (_event, value) =>
+          addFilterParam(filters, updateFilters, 'general_severity', value),
+        value: filters.general_severity,
+        items: WORKLOADS_TABLE_FILTER_CATEGORIES.general_severity.values,
+        placeholder: 'Filter by general severity',
+      },
+    },
   ];
 
   const activeFiltersConfig = {
-    showDeleteButton: true,
+    showDeleteButton: filtersApplied ? true : false,
     deleteTitle: 'Reset filters',
     filters: buildFilterChips(filters, WORKLOADS_TABLE_FILTER_CATEGORIES),
     onDelete: (_event, itemsToRemove, isAll) => {
@@ -191,7 +209,9 @@ const WorkloadsListTable = ({
           ouiaId: 'pager',
         }}
         filterConfig={{ items: filterConfigItems }}
-        activeFiltersConfig={activeFiltersConfig}
+        activeFiltersConfig={
+          isError ? { showDeleteButton: false } : activeFiltersConfig
+        }
       />
       <Table
         aria-label="Table of workloads"

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -34,6 +34,7 @@ import { ErrorState, NoMatchingClusters } from '../MessageState/EmptyStates';
 import Loading from '../Loading/Loading';
 import mockdata from '../../../cypress/fixtures/api/insights-results-aggregator/v2/workloads.json';
 import ShieldSet from '../ShieldSet';
+import { noFiltersApplied } from '../../Utilities/Workloads';
 
 const WorkloadsListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
@@ -47,9 +48,7 @@ const WorkloadsListTable = ({
   const [rows, setRows] = useState([]);
   const [filteredRows, setFilteredRows] = useState([]);
   const [rowsFiltered, setRowsFiltered] = useState(false);
-  const [filtersApplied] = useState(
-    filters === WORKLOADS_TABLE_INITIAL_STATE ? false : true
-  );
+  const [filtersApplied, setFiltersApplied] = useState(false);
   const updateFilters = (payload) =>
     dispatch(updateWorkloadsListFilters(payload));
   const removeFilterParam = (param) =>
@@ -65,6 +64,7 @@ const WorkloadsListTable = ({
     //should be refactored to smth like setDisplayedRows(buildDisplayedRows(filteredRows));
     //when we add pagination
     setRowsFiltered(true);
+    setFiltersApplied(noFiltersApplied(filters).length > 0 ? true : false);
   }, [data, filteredRows]);
 
   useEffect(() => {

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -135,21 +135,7 @@ const WorkloadsListTable = ({
       },
     },
     {
-      label: 'Highest severity',
-      type: conditionalFilterType.checkbox,
-      id: WORKLOADS_TABLE_FILTER_CATEGORIES.highest_severity.urlParam,
-      value: `checkbox-${WORKLOADS_TABLE_FILTER_CATEGORIES.highest_severity.urlParam}`,
-      filterValues: {
-        key: `${WORKLOADS_TABLE_FILTER_CATEGORIES.highest_severity.urlParam}-filter`,
-        onChange: (_event, value) =>
-          addFilterParam(filters, updateFilters, 'highest_severity', value),
-        value: filters.highest_severity,
-        items: WORKLOADS_TABLE_FILTER_CATEGORIES.highest_severity.values,
-        placeholder: 'Filter by highest severity',
-      },
-    },
-    {
-      label: 'General severity',
+      label: 'Severity',
       type: conditionalFilterType.checkbox,
       id: WORKLOADS_TABLE_FILTER_CATEGORIES.general_severity.urlParam,
       value: `checkbox-${WORKLOADS_TABLE_FILTER_CATEGORIES.general_severity.urlParam}`,
@@ -159,7 +145,7 @@ const WorkloadsListTable = ({
           addFilterParam(filters, updateFilters, 'general_severity', value),
         value: filters.general_severity,
         items: WORKLOADS_TABLE_FILTER_CATEGORIES.general_severity.values,
-        placeholder: 'Filter by general severity',
+        placeholder: 'Filter by severity',
       },
     },
   ];

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -28,6 +28,7 @@ import {
   addFilterParam,
   buildFilterChips,
   passFilterWorkloads,
+  removeFilterParam as _removeFilterParam,
 } from '../Common/Tables';
 import { ErrorState, NoMatchingClusters } from '../MessageState/EmptyStates';
 import Loading from '../Loading/Loading';
@@ -35,7 +36,7 @@ import mockdata from '../../../cypress/fixtures/api/insights-results-aggregator/
 import ShieldSet from '../ShieldSet';
 
 const WorkloadsListTable = ({
-  query: { isError, isUninitialized, isFetching, isSuccess, data },
+  query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
 }) => {
   const dispatch = useDispatch();
   const filters = useSelector(({ filters }) => filters.workloadsListState);
@@ -48,6 +49,8 @@ const WorkloadsListTable = ({
   const [rowsFiltered, setRowsFiltered] = useState(false);
   const updateFilters = (payload) =>
     dispatch(updateWorkloadsListFilters(payload));
+  const removeFilterParam = (param) =>
+    _removeFilterParam(filters, updateFilters, param);
 
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError;
@@ -154,7 +157,7 @@ const WorkloadsListTable = ({
     onDelete: (_event, itemsToRemove, isAll) => {
       if (isAll) {
         if (isEqual(filters, WORKLOADS_TABLE_INITIAL_STATE)) {
-          console.log('here should be a refetch!');
+          refetch();
         } else {
           resetFilters(filters, WORKLOADS_TABLE_INITIAL_STATE, updateFilters);
         }
@@ -169,9 +172,7 @@ const WorkloadsListTable = ({
           };
           newFilter[item.urlParam].length > 0
             ? updateFilters({ ...filters, ...newFilter })
-            : console.log(
-                'here we should remove the filter parameter from a URL!'
-              );
+            : removeFilterParam(item.urlParam);
         });
       }
     },

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -54,6 +54,7 @@ export const WORKLOADS_TABLE_INITIAL_STATE = {
   sortDirection: 'desc',
   cluster_name: '',
   namespace_name: '',
+  general_severity: [],
   highest_severity: [],
 };
 

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -55,7 +55,6 @@ export const WORKLOADS_TABLE_INITIAL_STATE = {
   cluster_name: '',
   namespace_name: '',
   general_severity: [],
-  highest_severity: [],
 };
 
 const filtersInitialState = {

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -1,3 +1,5 @@
+import _, { isEmpty } from 'lodash';
+
 export const SEVERITY_OPTIONS = [
   {
     value: 'critical',
@@ -33,7 +35,7 @@ export const SEVERITY_OPTIONS = [
   },
 ];
 
-export const remappingSeverity = (obj) => {
+export const remappingSeverity = (obj, mode) => {
   const mapping = {
     1: 'low',
     2: 'moderate',
@@ -42,10 +44,45 @@ export const remappingSeverity = (obj) => {
   };
   let updatedObj = {};
 
-  for (const key in obj) {
-    if (key in mapping) {
-      updatedObj[mapping[key]] = obj[key];
+  if (mode === 'general' || mode === 'label') {
+    for (const key in obj) {
+      if (key in mapping) {
+        updatedObj[mapping[key]] = obj[key];
+      }
+    }
+  } else {
+    updatedObj = mapping[obj];
+  }
+
+  return updatedObj;
+};
+
+export const hasAnyValueGreaterThanZero = (obj, stringsToCheck) => {
+  for (const key of stringsToCheck) {
+    if (obj[key] > 0) {
+      return true; // Return true if any matching string has a value greater than 0
     }
   }
-  return updatedObj;
+};
+
+export const severityTypeToText = (value) => {
+  value = parseInt(value);
+  if (value === 1) {
+    return 'Low';
+  } else if (value === 2) {
+    return 'Moderate';
+  } else if (value === 3) {
+    return 'Important';
+  } else {
+    return 'Critical';
+  }
+};
+
+export const noFiltersApplied = (params) => {
+  const cleanedUpParams = _.cloneDeep(params);
+  delete cleanedUpParams.sortIndex;
+  delete cleanedUpParams.sortDirection;
+  delete cleanedUpParams.offset;
+  delete cleanedUpParams.limit;
+  return Object.values(cleanedUpParams).filter((value) => !isEmpty(value));
 };


### PR DESCRIPTION
Working filters for the workloads table

No URL PARAMS YET! Gonna work on them in a separate PR

How to setup mock api:

Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock)
make build (takes a few minutes for me, coffee time ☕)
2.1. can speed it up with make build -j 4 to run multiple jobs at once
make run
Test the mocked api curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
Run the app MOCK=true npm run start:proxy:beta
Workloads should load mocked data

How to test with local data:
You can use the mock data provided from the json file - for that you need comment out data from props and use json 

