### PR TITLE
feat(OCPADVISOR-146): pagination for workloads table

### DIFF
--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -51,7 +51,6 @@ const WorkloadsListTable = ({
   const [filteredRows, setFilteredRows] = useState([]);
   const [rowsFiltered, setRowsFiltered] = useState(false);
   const [filtersApplied, setFiltersApplied] = useState(false);
-  const [tempQuery, setTempQuery] = useState(0);
   const updateFilters = (payload) =>
     dispatch(updateWorkloadsListFilters(payload));
   const removeFilterParam = (param) =>
@@ -65,7 +64,6 @@ const WorkloadsListTable = ({
   useEffect(() => {
     setFilteredRows(buildFilteredRows(workloads));
   }, [
-    tempQuery,
     filters.namespace_name,
     filters.cluster_name,
     filters.general_severity,
@@ -76,8 +74,6 @@ const WorkloadsListTable = ({
 
   useEffect(() => {
     setRows(buildDisplayedRows(filteredRows));
-    //should be refactored to smth like setDisplayedRows(buildDisplayedRows(filteredRows));
-    //when we add pagination
     setRowsFiltered(true);
     setFiltersApplied(noFiltersApplied(filters).length > 0 ? true : false);
   }, [filteredRows, filters.limit, filters.offset]);
@@ -194,10 +190,10 @@ const WorkloadsListTable = ({
   };
 
   const onSetPerPage = (_e, perPage) => {
-    //THIS IS A DUMMY QUERY THAT WILL BE REMOVED WHEN WE WORK ON CONNECTING FILTERS/SORTING/PAGES TO THE URL PARAMS
-    setTempQuery(Math.random());
-    setRowsFiltered(false);
-    updateFilters({ ...filters, limit: perPage, offset: 0 });
+    if (perPage !== filters.limit) {
+      setRowsFiltered(false);
+      updateFilters({ ...filters, limit: perPage, offset: 0 });
+    }
   };
 
   return (

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -51,6 +51,7 @@ const WorkloadsListTable = ({
   const [filteredRows, setFilteredRows] = useState([]);
   const [rowsFiltered, setRowsFiltered] = useState(false);
   const [filtersApplied, setFiltersApplied] = useState(false);
+  const [tempQuery, setTempQuery] = useState(0);
   const updateFilters = (payload) =>
     dispatch(updateWorkloadsListFilters(payload));
   const removeFilterParam = (param) =>
@@ -58,12 +59,13 @@ const WorkloadsListTable = ({
 
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError;
-  const noMatch = rows.length === 0;
+  const noMatch = rows.length > 0 && filteredRows.length === 0;
   const successState = isSuccess;
 
   useEffect(() => {
     setFilteredRows(buildFilteredRows(workloads));
   }, [
+    tempQuery,
     filters.namespace_name,
     filters.cluster_name,
     filters.general_severity,
@@ -192,6 +194,8 @@ const WorkloadsListTable = ({
   };
 
   const onSetPerPage = (_e, perPage) => {
+    //THIS IS A DUMMY QUERY THAT WILL BE REMOVED WHEN WE WORK ON CONNECTING FILTERS/SORTING/PAGES TO THE URL PARAMS
+    setTempQuery(Math.random());
     setRowsFiltered(false);
     updateFilters({ ...filters, limit: perPage, offset: 0 });
   };

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -32,9 +32,9 @@ import {
 } from '../Common/Tables';
 import { ErrorState, NoMatchingClusters } from '../MessageState/EmptyStates';
 import Loading from '../Loading/Loading';
-import mockdata from '../../../cypress/fixtures/api/insights-results-aggregator/v2/workloads.json';
 import ShieldSet from '../ShieldSet';
 import { noFiltersApplied } from '../../Utilities/Workloads';
+import mockdata from '../../../cypress/fixtures/api/insights-results-aggregator/v2/workloads.json';
 
 const WorkloadsListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
@@ -45,7 +45,7 @@ const WorkloadsListTable = ({
   //to check all types of filters use the mockdata json
   const workloads = mockdata;
   const perPage = filters.limit;
-  const page = filters.offset / filters.limit + 1;
+  const page = Math.floor(filters.offset / filters.limit) + 1;
 
   const [rows, setRows] = useState([]);
   const [filteredRows, setFilteredRows] = useState([]);

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -205,9 +205,9 @@ const WorkloadsListTable = ({
       <PrimaryToolbar
         pagination={{
           itemCount: data?.workloads.length || 0,
-          page: page,
-          perPage: perPage,
-          onSetPage: onSetPage,
+          page,
+          perPage,
+          onSetPage,
           onPerPageSelect: onSetPerPage,
           isCompact: true,
           ouiaId: 'pager',
@@ -257,9 +257,9 @@ const WorkloadsListTable = ({
       <Pagination
         ouiaId="pager"
         itemCount={data?.workloads.length || 0}
-        page={page}
-        perPage={perPage}
-        onSetPage={onSetPage}
+        page
+        perPage
+        onSetPage
         onPerPageSelect={onSetPerPage}
         onPageInput={onSetPage}
         widgetId={`pagination-options-menu-bottom`}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPADVISOR-146

Adds pagination to the workloads table

How to setup mock api:

Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock)
make build (takes a few minutes for me, coffee time ☕)
2.1. can speed it up with make build -j 4 to run multiple jobs at once
make run
Test the mocked api curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
Run the app MOCK=true npm run start:proxy:beta
Workloads should load mocked data