### PR TITLE
fix(OCPADVISOR-121): hotfix for workloads table

### DIFF
--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -75,6 +75,7 @@ const WorkloadsListTable = ({
   useEffect(() => {
     setFilteredRows(buildFilteredRows(workloads));
   }, [
+    data,
     filters.namespace_name,
     filters.cluster_name,
     filters.general_severity,


### PR DESCRIPTION
We have to subscribe to data in useEffect, so the table would show data on the initial load.