### PR TITLE
fix(RHINENG-5533): small fix about filtered values rows number

### DIFF
--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -208,9 +208,9 @@ const WorkloadRules = ({ workload }) => {
         }}
         pagination={
           <span className="pf-u-font-weight-bold">
-            {recommendations?.length === 1
-              ? `${recommendations.length} Recommendation`
-              : `${recommendations.length} Recommendations`}
+            {filteredRows?.length === 1
+              ? `${filteredRows.length} Recommendation`
+              : `${filteredRows.length} Recommendations`}
           </span>
         }
         activeFiltersConfig={


### PR DESCRIPTION
The recommendations number on the right side of the toolbar should represent the number of rows that are filtered and shown in the table. Previously it was showing just the number of rows received from the API
[Screencast from 2024-01-05 11-57-01.webm](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/e95be58d-754a-4017-bc1b-f8c18539100a)
