### PR TITLE
feat(RHINENG-5520): Workloads details sorting

### DIFF
--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
+  SortByDirection,
   Table,
   TableBody,
   TableHeader,
@@ -76,10 +77,34 @@ const WorkloadRules = ({ workload }) => {
   );
 
   const buildDisplayedRows = (filteredRows, sortIndex, sortDirection) => {
-    void sortIndex;
-    void sortDirection;
+    const sortingRows =
+      sortIndex >= 0 && !expandFirst
+        ? [...filteredRows].sort((a, b) => {
+            const d = sortDirection === SortByDirection.asc ? 1 : -1;
+            const getValue = (item) => {
+              switch (sortIndex) {
+                case 1:
+                  return item[0].rule.details;
+                case 2:
+                  console.log('total risk sorting - we need data in the api');
+                  break;
+                case 3:
+                  return item[0].rule.objects.length;
+                case 4:
+                  return item[0].rule.modified;
+                default:
+                  return 0;
+              }
+            };
+            return getValue(a, sortIndex) > getValue(b, sortIndex)
+              ? d
+              : getValue(b, sortIndex) > getValue(a, sortIndex)
+              ? -d
+              : 0;
+          })
+        : [...filteredRows];
 
-    return filteredRows.flatMap((row, index) => {
+    return sortingRows.flatMap((row, index) => {
       const updatedRow = [...row];
       if (expandFirst && index === 0) {
         row[0].isOpen = true;
@@ -198,6 +223,16 @@ const WorkloadRules = ({ workload }) => {
     },
   };
 
+  const onSort = (_e, index, direction) => {
+    setRowsFiltered(false);
+    setExpandFirst(false);
+    return updateFilters({
+      ...filters,
+      sortIndex: index,
+      sortDirection: direction,
+    });
+  };
+
   return (
     <div id="workload-recs-list-table">
       <PrimaryToolbar
@@ -250,6 +285,11 @@ const WorkloadRules = ({ workload }) => {
         variant={TableVariant.compact}
         isStickyHeader
         canCollapseAll
+        sortBy={{
+          index: filters.sortIndex,
+          direction: filters.sortDirection,
+        }}
+        onSort={onSort}
       >
         <TableHeader />
         <TableBody />

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -47,13 +47,17 @@ const WorkloadRules = ({ workload }) => {
   const [rowsFiltered, setRowsFiltered] = useState(false);
   const [filtersApplied, setFiltersApplied] = useState(false);
   const [expandFirst, setExpandFirst] = useState(true);
+  const [firstRule, setFirstRule] = useState('');
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   //FILTERS
   const filters = useSelector(({ filters }) => filters.workloadsRecsListState);
+
   const updateFilters = (payload) =>
     dispatch(updateWorkloadsRecsListFilters(payload));
+
   const addFilterParam = (param, values) => {
     setExpandFirst(false);
+    setFirstRule('');
     return _addFilterParam(filters, updateFilters, param, values);
   };
   const removeFilterParam = (param) =>
@@ -78,7 +82,7 @@ const WorkloadRules = ({ workload }) => {
 
   const buildDisplayedRows = (filteredRows, sortIndex, sortDirection) => {
     const sortingRows =
-      sortIndex >= 0 && !expandFirst
+      sortIndex >= 0 && !firstRule
         ? [...filteredRows].sort((a, b) => {
             const d = sortDirection === SortByDirection.asc ? 1 : -1;
             const getValue = (item) => {
@@ -226,6 +230,7 @@ const WorkloadRules = ({ workload }) => {
   const onSort = (_e, index, direction) => {
     setRowsFiltered(false);
     setExpandFirst(false);
+    setFirstRule('');
     return updateFilters({
       ...filters,
       sortIndex: index,

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import {
-  SortByDirection,
   Table,
   TableBody,
   TableHeader,
@@ -32,7 +31,9 @@ import {
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import {
   filtersAreApplied,
+  flatMapRows,
   pruneWorkloadsRulesFilters,
+  sortWithSwitch,
 } from '../../Utilities/Workloads';
 
 const WorkloadRules = ({ workload }) => {
@@ -81,41 +82,13 @@ const WorkloadRules = ({ workload }) => {
   );
 
   const buildDisplayedRows = (filteredRows, sortIndex, sortDirection) => {
-    const sortingRows =
-      sortIndex >= 0 && !firstRule
-        ? [...filteredRows].sort((a, b) => {
-            const d = sortDirection === SortByDirection.asc ? 1 : -1;
-            const getValue = (item) => {
-              switch (sortIndex) {
-                case 1:
-                  return item[0].rule.details;
-                case 2:
-                  console.log('total risk sorting - we need data in the api');
-                  break;
-                case 3:
-                  return item[0].rule.objects.length;
-                case 4:
-                  return item[0].rule.modified;
-                default:
-                  return 0;
-              }
-            };
-            return getValue(a, sortIndex) > getValue(b, sortIndex)
-              ? d
-              : getValue(b, sortIndex) > getValue(a, sortIndex)
-              ? -d
-              : 0;
-          })
-        : [...filteredRows];
-
-    return sortingRows.flatMap((row, index) => {
-      const updatedRow = [...row];
-      if (expandFirst && index === 0) {
-        row[0].isOpen = true;
-      }
-      row[1].parent = index * 2;
-      return updatedRow;
-    });
+    const sortingRows = sortWithSwitch(
+      sortIndex,
+      sortDirection,
+      filteredRows,
+      firstRule
+    );
+    return flatMapRows(sortingRows, expandFirst);
   };
 
   const handleOnCollapse = (_e, rowId, isOpen) => {

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -48,7 +48,6 @@ const WorkloadRules = ({ workload }) => {
   const [rowsFiltered, setRowsFiltered] = useState(false);
   const [filtersApplied, setFiltersApplied] = useState(false);
   const [expandFirst, setExpandFirst] = useState(true);
-  const [firstRule, setFirstRule] = useState('');
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   //FILTERS
   const filters = useSelector(({ filters }) => filters.workloadsRecsListState);
@@ -58,7 +57,6 @@ const WorkloadRules = ({ workload }) => {
 
   const addFilterParam = (param, values) => {
     setExpandFirst(false);
-    setFirstRule('');
     return _addFilterParam(filters, updateFilters, param, values);
   };
   const removeFilterParam = (param) =>
@@ -82,12 +80,7 @@ const WorkloadRules = ({ workload }) => {
   );
 
   const buildDisplayedRows = (filteredRows, sortIndex, sortDirection) => {
-    const sortingRows = sortWithSwitch(
-      sortIndex,
-      sortDirection,
-      filteredRows,
-      firstRule
-    );
+    const sortingRows = sortWithSwitch(sortIndex, sortDirection, filteredRows);
     return flatMapRows(sortingRows, expandFirst);
   };
 
@@ -203,7 +196,6 @@ const WorkloadRules = ({ workload }) => {
   const onSort = (_e, index, direction) => {
     setRowsFiltered(false);
     setExpandFirst(false);
-    setFirstRule('');
     updateFilters({
       ...filters,
       sortIndex: index,

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -204,7 +204,7 @@ const WorkloadRules = ({ workload }) => {
     setRowsFiltered(false);
     setExpandFirst(false);
     setFirstRule('');
-    return updateFilters({
+    updateFilters({
       ...filters,
       sortIndex: index,
       sortDirection: direction,

--- a/src/Components/WorkloadRules/WorkloadsRules.test.js
+++ b/src/Components/WorkloadRules/WorkloadsRules.test.js
@@ -108,42 +108,39 @@ describe('switchSort function', () => {
     const result = switchSort(4, item);
     expect(result).toBe('2024-01-10');
   });
-
-  test('should return 0 for invalid sortIndex', () => {
-    const item = [{ rule: {} }];
-    const result = switchSort(5, item);
-    expect(result).toBe(0);
-  });
 });
 
 describe('sortWithSwitch function', () => {
   test('should return original rows if sortIndex is invalid or firstRule is true', () => {
-    const filteredRows = [{ rule: { details: 'abc' } }];
+    const filteredRows = [
+      [{ rule: { details: 'abc' } }],
+      [{ rule: { details: 'xyz' } }],
+    ];
     const result = sortWithSwitch(5, SortByDirection.asc, filteredRows, false);
     expect(result).toEqual(filteredRows);
   });
 
   test('should sort rows in ascending order based on switchSort', () => {
     const filteredRows = [
-      { rule: { details: 'abc' } },
-      { rule: { details: 'xyz' } },
+      [{ rule: { details: 'abc' } }],
+      [{ rule: { details: 'xyz' } }],
     ];
-    const result = sortWithSwitch(1, SortByDirection.asc, filteredRows, false);
+    const result = sortWithSwitch(1, SortByDirection.asc, filteredRows);
     expect(result).toEqual([
-      { rule: { details: 'abc' } },
-      { rule: { details: 'xyz' } },
+      [{ rule: { details: 'abc' } }],
+      [{ rule: { details: 'xyz' } }],
     ]);
   });
 
   test('should sort rows in descending order based on switchSort', () => {
     const filteredRows = [
-      { rule: { details: 'abc' } },
-      { rule: { details: 'xyz' } },
+      [{ rule: { details: 'abc' } }],
+      [{ rule: { details: 'xyz' } }],
     ];
-    const result = sortWithSwitch(1, SortByDirection.desc, filteredRows, false);
+    const result = sortWithSwitch(1, SortByDirection.desc, filteredRows);
     expect(result).toEqual([
-      { rule: { details: 'abc' } },
-      { rule: { details: 'xyz' } },
+      [{ rule: { details: 'xyz' } }],
+      [{ rule: { details: 'abc' } }],
     ]);
   });
 });

--- a/src/Components/WorkloadRules/WorkloadsRules.test.js
+++ b/src/Components/WorkloadRules/WorkloadsRules.test.js
@@ -2,6 +2,8 @@ import {
   capitalize,
   createChips,
   pruneWorkloadsRulesFilters,
+  switchSort,
+  sortWithSwitch,
 } from '../../Utilities/Workloads';
 
 describe('capitalize function', () => {
@@ -72,6 +74,76 @@ describe('pruneWorkloadsRulesFilters function', () => {
         chips: [{ name: '12345', value: '12345' }],
         urlParam: 'object_id',
       },
+    ]);
+  });
+});
+
+// Mocking SortByDirection for testing purposes
+const SortByDirection = {
+  asc: 'asc',
+  desc: 'desc',
+};
+
+describe('switchSort function', () => {
+  test('should return details for sortIndex 1', () => {
+    const item = [{ rule: { details: 'someDetails' } }];
+    const result = switchSort(1, item);
+    expect(result).toBe('someDetails');
+  });
+
+  test('should return total_risk for sortIndex 2', () => {
+    const item = [{ rule: { total_risk: 42 } }];
+    const result = switchSort(2, item);
+    expect(result).toBe(42);
+  });
+
+  test('should return objects length for sortIndex 3', () => {
+    const item = [{ rule: { objects: [1, 2, 3] } }];
+    const result = switchSort(3, item);
+    expect(result).toBe(3);
+  });
+
+  test('should return modified for sortIndex 4', () => {
+    const item = [{ rule: { modified: '2024-01-10' } }];
+    const result = switchSort(4, item);
+    expect(result).toBe('2024-01-10');
+  });
+
+  test('should return 0 for invalid sortIndex', () => {
+    const item = [{ rule: {} }];
+    const result = switchSort(5, item);
+    expect(result).toBe(0);
+  });
+});
+
+describe('sortWithSwitch function', () => {
+  test('should return original rows if sortIndex is invalid or firstRule is true', () => {
+    const filteredRows = [{ rule: { details: 'abc' } }];
+    const result = sortWithSwitch(5, SortByDirection.asc, filteredRows, false);
+    expect(result).toEqual(filteredRows);
+  });
+
+  test('should sort rows in ascending order based on switchSort', () => {
+    const filteredRows = [
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
+    ];
+    const result = sortWithSwitch(1, SortByDirection.asc, filteredRows, false);
+    expect(result).toEqual([
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
+    ]);
+  });
+
+  test('should sort rows in descending order based on switchSort', () => {
+    const filteredRows = [
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
+    ];
+    const result = sortWithSwitch(1, SortByDirection.desc, filteredRows, false);
+    expect(result).toEqual([
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
     ]);
   });
 });

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -147,29 +147,22 @@ export const pruneWorkloadsRulesFilters = (localFilters, filterCategories) => {
 };
 
 export const switchSort = (sortIndex, item) => {
-  const rule = item[0]?.rule; // Using optional chaining to check if 'rule' is defined
+  const rule = item[0].rule;
   switch (sortIndex) {
     case 1:
       return rule?.details || '';
     case 2:
-      return rule?.total_risk || [];
+      return rule?.total_risk || '';
     case 3:
       return rule?.objects?.length || 0;
     case 4:
       return rule?.modified || '';
-    default:
-      return 0;
   }
 };
 
-export const sortWithSwitch = (
-  sortIndex,
-  sortDirection,
-  filteredRows,
-  firstRule
-) => {
-  return sortIndex >= 0 && !firstRule
-    ? [...filteredRows].sort((a, b) => {
+export const sortWithSwitch = (sortIndex, sortDirection, filteredRows) => {
+  return sortIndex >= 1
+    ? [...filteredRows]?.sort((a, b) => {
         const d = sortDirection === SortByDirection.asc ? 1 : -1;
         return switchSort(sortIndex, a) > switchSort(sortIndex, b)
           ? d

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -150,13 +150,13 @@ export const switchSort = (sortIndex, item) => {
   const rule = item[0].rule;
   switch (sortIndex) {
     case 1:
-      return rule?.details || '';
+      return rule.details;
     case 2:
-      return rule?.total_risk || '';
+      return rule.total_risk;
     case 3:
-      return rule?.objects?.length || 0;
+      return rule.objects.length;
     case 4:
-      return rule?.modified || '';
+      return rule.modified;
   }
 };
 

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -1,3 +1,4 @@
+import { SortByDirection } from '@patternfly/react-table';
 import _, { isEmpty } from 'lodash';
 
 export const SEVERITY_OPTIONS = [
@@ -143,4 +144,49 @@ export const pruneWorkloadsRulesFilters = (localFilters, filterCategories) => {
 
     return arr;
   }, []);
+};
+
+export const switchSort = (sortIndex, item) => {
+  const rule = item[0]?.rule; // Using optional chaining to check if 'rule' is defined
+  switch (sortIndex) {
+    case 1:
+      return rule?.details || '';
+    case 2:
+      return rule?.total_risk || [];
+    case 3:
+      return rule?.objects?.length || 0;
+    case 4:
+      return rule?.modified || '';
+    default:
+      return 0;
+  }
+};
+
+export const sortWithSwitch = (
+  sortIndex,
+  sortDirection,
+  filteredRows,
+  firstRule
+) => {
+  return sortIndex >= 0 && !firstRule
+    ? [...filteredRows].sort((a, b) => {
+        const d = sortDirection === SortByDirection.asc ? 1 : -1;
+        return switchSort(sortIndex, a) > switchSort(sortIndex, b)
+          ? d
+          : switchSort(sortIndex, b) > switchSort(sortIndex, a)
+          ? -d
+          : 0;
+      })
+    : [...filteredRows];
+};
+
+export const flatMapRows = (filteredRows, expandFirst) => {
+  return filteredRows.flatMap((row, index) => {
+    const updatedRow = [...row];
+    if (expandFirst && index === 0) {
+      row[0].isOpen = true;
+    }
+    row[1].parent = index * 2;
+    return updatedRow;
+  });
 };


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/RHINENG-5520
This PR covers sorting for the Description, Objects, and Modified columns. It doesn't cover the total risk column sorting because data is not available in the API yet.
When the first row is expanded and you click on the sort arrow it won't work. It is expected. This is gonna be fixed in a separate PR and covered by a separate Jira card.

How to check the PR 

1. Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock) or pull the latest changes
2. make build
3. can speed it up with make build -j 4 to run multiple jobs at once
4. make run
5. Test the mocked api curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
6. Run the app MOCK=true npm run start:proxy:beta
7. Workloads should load mocked data
8. Review the PR