### PR TITLE
feat(RHINENG-6801): Workloads rules url params & filters

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -527,3 +527,11 @@ export const WORKLOADS_RULES_FILTER_CONFIG = (filters, addParamFunction) => [
     },
   },
 ];
+
+export const WORKLOADS_RULES_COLUMNS_KEYS = [
+  '', // reserved for expand button
+  'description',
+  'total_risk',
+  'objects',
+  'modified',
+];

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -199,6 +199,9 @@ export const paramParser = (search) => {
         'sort',
         'cluster_name',
         'namespace_name',
+        'description',
+        'object_id',
+        'total_risk',
       ].includes(key)
         ? value // just copy the full value
         : value === 'true' || value === 'false'
@@ -213,6 +216,7 @@ export const paramParser = (search) => {
 export const translateSortParams = (value) => ({
   name: value.substring(value.startsWith('-') ? 1 : 0),
   direction: value.startsWith('-') ? 'desc' : 'asc',
+  description: value.substring(value.startsWith('-') ? 1 : 0),
 });
 
 export const translateSortValue = (index, indexMapping, direction) => {
@@ -315,24 +319,20 @@ export const passFilterWorkloads = (workloads, filters) => {
 
 export const passFilterWorkloadsRecs = (recommendation, filters) => {
   return Object.entries(filters).some(([filterKey, filterValue]) => {
-    if (filterValue.length === 0) {
-      return false;
-    } else {
-      switch (filterKey) {
-        case 'description':
-          return recommendation.details
-            .toLowerCase()
-            .includes(filterValue.toLowerCase());
-        case 'object_id':
-          return recommendation.objects.some((obj) =>
-            obj.uid.toLowerCase().includes(filterValue.toLowerCase())
-          );
-        //NOTE IS NOT AVAILABLE IN THE API YET
-        /* case 'total_risk':
+    switch (filterKey) {
+      case 'description':
+        return recommendation.details
+          .toLowerCase()
+          .includes(filterValue.toLowerCase());
+      case 'object_id':
+        return recommendation.objects.some((obj) =>
+          obj.uid.toLowerCase().includes(filterValue.toLowerCase())
+        );
+      //NOTE IS NOT AVAILABLE IN THE API YET
+      /* case 'total_risk':
         return filterValue.includes(String(recs.total_risk)); */
-        default:
-          return false;
-      }
+      default:
+        return false;
     }
   });
 };

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -216,6 +216,7 @@ export const translateSortParams = (value) => ({
   name: value.substring(value.startsWith('-') ? 1 : 0),
   direction: value.startsWith('-') ? 'desc' : 'asc',
   description: value.substring(value.startsWith('-') ? 1 : 0),
+  object_id: value.substring(value.startsWith('-') ? 1 : 0),
 });
 
 export const translateSortValue = (index, indexMapping, direction) => {
@@ -317,21 +318,27 @@ export const passFilterWorkloads = (workloads, filters) => {
 };
 
 export const passFilterWorkloadsRecs = (recommendation, filters) => {
+  console.log(recommendation, 'recommendation');
+  console.log(filters, 'filters');
   return Object.entries(filters).some(([filterKey, filterValue]) => {
-    switch (filterKey) {
-      case 'description':
-        return recommendation.details
-          .toLowerCase()
-          .includes(filterValue.toLowerCase());
-      case 'object_id':
-        return recommendation.objects.some((obj) =>
-          obj.uid.toLowerCase().includes(filterValue.toLowerCase())
-        );
-      //NOTE IS NOT AVAILABLE IN THE API YET
-      /* case 'total_risk':
+    if (filterValue.length === 0) {
+      return false;
+    } else {
+      switch (filterKey) {
+        case 'description':
+          return recommendation.details
+            .toLowerCase()
+            .includes(filterValue.toLowerCase());
+        case 'object_id':
+          return recommendation.objects.some((obj) =>
+            obj.uid.toLowerCase().includes(filterValue.toLowerCase())
+          );
+        //NOTE IS NOT AVAILABLE IN THE API YET
+        /* case 'total_risk':
         return filterValue.includes(String(recs.total_risk)); */
-      default:
-        return false;
+        default:
+          return false;
+      }
     }
   });
 };

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -201,7 +201,6 @@ export const paramParser = (search) => {
         'namespace_name',
         'description',
         'object_id',
-        'total_risk',
       ].includes(key)
         ? value // just copy the full value
         : value === 'true' || value === 'false'

--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -318,8 +318,6 @@ export const passFilterWorkloads = (workloads, filters) => {
 };
 
 export const passFilterWorkloadsRecs = (recommendation, filters) => {
-  console.log(recommendation, 'recommendation');
-  console.log(filters, 'filters');
   return Object.entries(filters).some(([filterKey, filterValue]) => {
     if (filterValue.length === 0) {
       return false;

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
+  SortByDirection,
   Table,
   TableBody,
   TableHeader,
@@ -76,10 +77,34 @@ const WorkloadRules = ({ workload }) => {
   );
 
   const buildDisplayedRows = (filteredRows, sortIndex, sortDirection) => {
-    void sortIndex;
-    void sortDirection;
+    const sortingRows =
+      sortIndex >= 0 && !expandFirst
+        ? [...filteredRows].sort((a, b) => {
+            const d = sortDirection === SortByDirection.asc ? 1 : -1;
+            const getValue = (item) => {
+              switch (sortIndex) {
+                case 1:
+                  return item[0].rule.details;
+                case 2:
+                  console.log('total risk sorting - we need data in the api');
+                  break;
+                case 3:
+                  return item[0].rule.objects.length;
+                case 4:
+                  return item[0].rule.modified;
+                default:
+                  return 0;
+              }
+            };
+            return getValue(a, sortIndex) > getValue(b, sortIndex)
+              ? d
+              : getValue(b, sortIndex) > getValue(a, sortIndex)
+              ? -d
+              : 0;
+          })
+        : [...filteredRows];
 
-    return filteredRows.flatMap((row, index) => {
+    return sortingRows.flatMap((row, index) => {
       const updatedRow = [...row];
       if (expandFirst && index === 0) {
         row[0].isOpen = true;
@@ -198,6 +223,16 @@ const WorkloadRules = ({ workload }) => {
     },
   };
 
+  const onSort = (_e, index, direction) => {
+    setRowsFiltered(false);
+    setExpandFirst(false);
+    return updateFilters({
+      ...filters,
+      sortIndex: index,
+      sortDirection: direction,
+    });
+  };
+
   return (
     <div id="workload-recs-list-table">
       <PrimaryToolbar
@@ -250,6 +285,11 @@ const WorkloadRules = ({ workload }) => {
         variant={TableVariant.compact}
         isStickyHeader
         canCollapseAll
+        sortBy={{
+          index: filters.sortIndex,
+          direction: filters.sortDirection,
+        }}
+        onSort={onSort}
       >
         <TableHeader />
         <TableBody />

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -64,7 +64,7 @@ const WorkloadRules = ({ workload }) => {
 
   const addFilterParam = (param, values) => {
     setExpandFirst(false);
-    return workloadsRulesAddFilterParam(filters, updateFilters, param, values);
+    workloadsRulesAddFilterParam(filters, updateFilters, param, values);
   };
   const removeFilterParam = (param) =>
     workloadsRulesRemoveFilterParam(filters, updateFilters, param);

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -90,7 +90,6 @@ const WorkloadRules = ({ workload }) => {
   useEffect(() => {
     if (search && filterBuilding) {
       const paramsObject = paramParser(search);
-
       if (paramsObject.sort) {
         const sortObj = translateSortParams(paramsObject.sort);
         paramsObject.sortIndex = WORKLOADS_RULES_COLUMNS_KEYS.indexOf(
@@ -172,10 +171,10 @@ const WorkloadRules = ({ workload }) => {
 
   const buildFilteredRows = (allRows, filters) => {
     setRowsFiltered(false);
-    const noFilters = filtersAreApplied(filters);
+    const filtersArePresent = filtersAreApplied(filters);
     return allRows
       .filter((recs) =>
-        noFilters ? passFilterWorkloadsRecs(recs, filters) : true
+        filtersArePresent ? passFilterWorkloadsRecs(recs, filters) : true
       )
       .map((value, key) => [
         {
@@ -232,7 +231,7 @@ const WorkloadRules = ({ workload }) => {
   };
 
   const activeFiltersConfig = {
-    showDeleteButton: filtersApplied ? true : false,
+    showDeleteButton: filtersApplied,
     deleteTitle: 'Reset filters',
     filters: buildFilterChips(),
     onDelete: (_event, itemsToRemove, isAll) => {

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -47,13 +47,17 @@ const WorkloadRules = ({ workload }) => {
   const [rowsFiltered, setRowsFiltered] = useState(false);
   const [filtersApplied, setFiltersApplied] = useState(false);
   const [expandFirst, setExpandFirst] = useState(true);
+  const [firstRule, setFirstRule] = useState('');
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   //FILTERS
   const filters = useSelector(({ filters }) => filters.workloadsRecsListState);
+
   const updateFilters = (payload) =>
     dispatch(updateWorkloadsRecsListFilters(payload));
+
   const addFilterParam = (param, values) => {
     setExpandFirst(false);
+    setFirstRule('');
     return _addFilterParam(filters, updateFilters, param, values);
   };
   const removeFilterParam = (param) =>
@@ -78,7 +82,7 @@ const WorkloadRules = ({ workload }) => {
 
   const buildDisplayedRows = (filteredRows, sortIndex, sortDirection) => {
     const sortingRows =
-      sortIndex >= 0 && !expandFirst
+      sortIndex >= 0 && !firstRule
         ? [...filteredRows].sort((a, b) => {
             const d = sortDirection === SortByDirection.asc ? 1 : -1;
             const getValue = (item) => {
@@ -226,6 +230,7 @@ const WorkloadRules = ({ workload }) => {
   const onSort = (_e, index, direction) => {
     setRowsFiltered(false);
     setExpandFirst(false);
+    setFirstRule('');
     return updateFilters({
       ...filters,
       sortIndex: index,

--- a/src/Components/WorkloadRules/WorkloadsRules.test.js
+++ b/src/Components/WorkloadRules/WorkloadsRules.test.js
@@ -2,6 +2,10 @@ import {
   capitalize,
   createChips,
   pruneWorkloadsRulesFilters,
+  switchSort,
+  sortWithSwitch,
+  workloadsRulesRemoveFilterParam,
+  workloadsRulesAddFilterParam,
 } from '../../Utilities/Workloads';
 
 describe('capitalize function', () => {
@@ -73,5 +77,165 @@ describe('pruneWorkloadsRulesFilters function', () => {
         urlParam: 'object_id',
       },
     ]);
+  });
+});
+
+// Mocking SortByDirection for testing purposes
+const SortByDirection = {
+  asc: 'asc',
+  desc: 'desc',
+};
+
+describe('switchSort function', () => {
+  test('should return details for sortIndex 1', () => {
+    const item = [{ rule: { details: 'someDetails' } }];
+    const result = switchSort(1, item);
+    expect(result).toBe('someDetails');
+  });
+
+  test('should return total_risk for sortIndex 2', () => {
+    const item = [{ rule: { total_risk: 42 } }];
+    const result = switchSort(2, item);
+    expect(result).toBe(42);
+  });
+
+  test('should return objects length for sortIndex 3', () => {
+    const item = [{ rule: { objects: [1, 2, 3] } }];
+    const result = switchSort(3, item);
+    expect(result).toBe(3);
+  });
+
+  test('should return modified for sortIndex 4', () => {
+    const item = [{ rule: { modified: '2024-01-10' } }];
+    const result = switchSort(4, item);
+    expect(result).toBe('2024-01-10');
+  });
+
+  test('should return 0 for invalid sortIndex', () => {
+    const item = [{ rule: {} }];
+    const result = switchSort(5, item);
+    expect(result).toBe(0);
+  });
+});
+
+describe('sortWithSwitch function', () => {
+  test('should return original rows if sortIndex is invalid or firstRule is true', () => {
+    const filteredRows = [{ rule: { details: 'abc' } }];
+    const result = sortWithSwitch(5, SortByDirection.asc, filteredRows, false);
+    expect(result).toEqual(filteredRows);
+  });
+
+  test('should sort rows in ascending order based on switchSort', () => {
+    const filteredRows = [
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
+    ];
+    const result = sortWithSwitch(1, SortByDirection.asc, filteredRows, false);
+    expect(result).toEqual([
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
+    ]);
+  });
+
+  test('should sort rows in descending order based on switchSort', () => {
+    const filteredRows = [
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
+    ];
+    const result = sortWithSwitch(1, SortByDirection.desc, filteredRows, false);
+    expect(result).toEqual([
+      { rule: { details: 'abc' } },
+      { rule: { details: 'xyz' } },
+    ]);
+  });
+});
+
+describe('workloadsRulesRemoveFilterParam', () => {
+  it('should remove the specified filter param', () => {
+    const currentFilters = {
+      description: 'example',
+      total_risk: [],
+      object_id: '123',
+    };
+    const updateFiltersMock = jest.fn();
+
+    workloadsRulesRemoveFilterParam(
+      currentFilters,
+      updateFiltersMock,
+      'description'
+    );
+
+    expect(updateFiltersMock).toHaveBeenCalledWith({
+      total_risk: [],
+      object_id: '123',
+      description: '',
+    });
+  });
+
+  it('should remove the total_risk filter param', () => {
+    const currentFilters = {
+      description: 'example',
+      total_risk: [1, 2, 3],
+      object_id: '123',
+    };
+    const updateFiltersMock = jest.fn();
+
+    workloadsRulesRemoveFilterParam(
+      currentFilters,
+      updateFiltersMock,
+      'total_risk'
+    );
+
+    expect(updateFiltersMock).toHaveBeenCalledWith({
+      description: 'example',
+      object_id: '123',
+      total_risk: [],
+    });
+  });
+});
+
+describe('workloadsRulesAddFilterParam', () => {
+  it('should add values to the specified filter param', () => {
+    const currentFilters = {
+      description: 'example',
+      total_risk: [],
+      object_id: '123',
+    };
+    const updateFiltersMock = jest.fn();
+
+    workloadsRulesAddFilterParam(
+      currentFilters,
+      updateFiltersMock,
+      'total_risk',
+      [1, 2, 3]
+    );
+
+    expect(updateFiltersMock).toHaveBeenCalledWith({
+      description: 'example',
+      object_id: '123',
+      total_risk: [1, 2, 3],
+    });
+  });
+
+  it('should remove the filter param if values are empty', () => {
+    const currentFilters = {
+      description: 'example',
+      total_risk: [1, 2, 3],
+      object_id: '123',
+    };
+    const updateFiltersMock = jest.fn();
+
+    workloadsRulesAddFilterParam(
+      currentFilters,
+      updateFiltersMock,
+      'total_risk',
+      []
+    );
+
+    expect(updateFiltersMock).toHaveBeenCalledWith({
+      description: 'example',
+      object_id: '123',
+      total_risk: [],
+    });
   });
 });

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -58,7 +58,6 @@ export const WORKLOADS_TABLE_INITIAL_STATE = {
 };
 
 export const WORKLOADS_RECS_TABLE_INITIAL_STATE = {
-  limit: 50,
   sortIndex: 1,
   sortDirection: 'desc',
   description: '',

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -1,3 +1,4 @@
+import { SortByDirection } from '@patternfly/react-table';
 import _, { isEmpty } from 'lodash';
 
 export const SEVERITY_OPTIONS = [
@@ -145,3 +146,79 @@ export const pruneWorkloadsRulesFilters = (localFilters, filterCategories) => {
     return arr;
   }, []);
 };
+
+export const switchSort = (sortIndex, item) => {
+  const rule = item[0]?.rule; // Using optional chaining to check if 'rule' is defined
+  switch (sortIndex) {
+    case 1:
+      return rule?.details || '';
+    case 2:
+      return rule?.total_risk || [];
+    case 3:
+      return rule?.objects?.length || 0;
+    case 4:
+      return rule?.modified || '';
+    default:
+      return 0;
+  }
+};
+
+export const sortWithSwitch = (
+  sortIndex,
+  sortDirection,
+  filteredRows,
+  firstRule
+) => {
+  return sortIndex >= 0 && !firstRule
+    ? [...filteredRows].sort((a, b) => {
+        const d = sortDirection === SortByDirection.asc ? 1 : -1;
+        return switchSort(sortIndex, a) > switchSort(sortIndex, b)
+          ? d
+          : switchSort(sortIndex, b) > switchSort(sortIndex, a)
+          ? -d
+          : 0;
+      })
+    : [...filteredRows];
+};
+
+export const flatMapRows = (filteredRows, expandFirst) => {
+  return filteredRows.flatMap((row, index) => {
+    const updatedRow = [...row];
+    if (expandFirst && index === 0) {
+      row[0].isOpen = true;
+    }
+    row[1].parent = index * 2;
+    return updatedRow;
+  });
+};
+
+export const workloadsRulesRemoveFilterParam = (
+  currentFilters,
+  updateFilters,
+  param
+) => {
+  const { [param]: omitted, ...newFilters } = { ...currentFilters };
+  updateFilters({
+    ...newFilters,
+    ...(param === 'description'
+      ? { description: '' }
+      : param === 'total_risk'
+      ? { total_risk: [] }
+      : param === 'object_id'
+      ? { object_id: '' }
+      : {}),
+  });
+};
+
+export const workloadsRulesAddFilterParam = (
+  currentFilters,
+  updateFilters,
+  param,
+  values
+) =>
+  values.length > 0
+    ? updateFilters({
+        ...currentFilters,
+        ...{ [param]: values },
+      })
+    : workloadsRulesRemoveFilterParam(currentFilters, updateFilters, param);

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -84,6 +84,7 @@ export const filtersAreApplied = (params) => {
   delete cleanedUpParams.sortDirection;
   delete cleanedUpParams.offset;
   delete cleanedUpParams.limit;
+  delete cleanedUpParams.sort;
   return Object.values(cleanedUpParams).filter((value) => !isEmpty(value))
     .length
     ? true


### PR DESCRIPTION
This PR is dependent on the https://github.com/RedHatInsights/ocp-advisor-frontend/pull/653
otherwise, it's hard to make URL params work for the sorting :) 

TOTAL RISK is not present in the API yet, so filtering and sorting by this parameter won't work

There is an issue that for some reason I get offset applied to the URL so I have to fix that as well


How to check the PR
Check that filters and sorting are correctly added to the URL params.

How to run it locally:
1. Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock) or pull the latest changes
2. make build
3. can speed it up with make build -j 4 to run multiple jobs at once
4. make run
5. Test the mocked api curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
6. Run the app MOCK=true npm run start:proxy:beta
7. Workloads should load mocked data
8. Review the PR