### PR TITLE
feat(rhineng-5519): empty states for workloads details

### DIFF
--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -273,6 +273,53 @@ const NoWorkloadsAvailable = () => {
   );
 };
 
+const NoWorkloadsRecsAvailable = () => {
+  return (
+    <MessageState
+      icon={ExclamationCircleIcon}
+      iconStyle={{ color: globalDangerColor100.value }}
+      title="Unable to connect"
+      text={
+        <>
+          <p>Check your connection and reload the page.</p>
+          <Button
+            variant="primary"
+            className="pf-v5-u-mt-xl"
+            onClick={() => history.back()}
+          >
+            Return to previous page
+          </Button>
+          <br />
+        </>
+      }
+    />
+  );
+};
+
+const NoRecsForWorkloadsDetails = () => {
+  return (
+    <MessageState
+      icon={CheckCircleIcon}
+      iconStyle={{
+        color: globalSuccessColor100.value,
+      }}
+      title="No workload recommendations"
+      text={
+        <>
+          <p>There are no recommendations for this workload.</p>
+          <Button
+            variant="primary"
+            className="pf-v5-u-mt-xl"
+            onClick={() => history.back()}
+          >
+            Return to previous page
+          </Button>
+        </>
+      }
+    />
+  );
+};
+
 export {
   ErrorState,
   NoAffectedClusters,
@@ -287,4 +334,6 @@ export {
   UpdateRisksNotAvailable,
   NoRecsForWorkloads,
   NoWorkloadsAvailable,
+  NoWorkloadsRecsAvailable,
+  NoRecsForWorkloadsDetails,
 };

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -13,7 +13,11 @@ import {
 } from '../../AppConstants';
 import PropTypes from 'prop-types';
 import Loading from '../Loading/Loading';
-import { ErrorState } from '../MessageState/EmptyStates';
+import {
+  ErrorState,
+  NoRecsForWorkloadsDetails,
+  NoWorkloadsRecsAvailable,
+} from '../MessageState/EmptyStates';
 // import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat/DateFormat';
 import InsightsLabel from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import ExpandedRulesDetails from '../ExpandedRulesDetails.js/ExpandedRulesDetails';
@@ -40,6 +44,7 @@ const WorkloadRules = ({ workload }) => {
   const recommendations = data?.recommendations || [];
   const errorState = isError;
   const successState = isSuccess;
+  const noInput = successState && recommendations.length === 0;
   const [isAllExpanded, setIsAllExpanded] = useState(false);
   const [filteredRows, setFilteredRows] = useState([]);
   const [displayedRows, setDisplayedRows] = useState([]);
@@ -204,7 +209,10 @@ const WorkloadRules = ({ workload }) => {
         filterConfig={{
           items: filterConfigItems,
           isDisabled:
-            loadingState || errorState || recommendations.length === 0,
+            loadingState ||
+            errorState ||
+            noInput ||
+            recommendations.length === 0,
         }}
         pagination={
           <span className="pf-u-font-weight-bold">
@@ -214,7 +222,7 @@ const WorkloadRules = ({ workload }) => {
           </span>
         }
         activeFiltersConfig={
-          loadingState || errorState || recommendations.length === 0
+          loadingState || errorState || noInput || recommendations.length === 0
             ? undefined
             : activeFiltersConfig
         }
@@ -226,7 +234,7 @@ const WorkloadRules = ({ workload }) => {
         ouiaSafe={!loadingState}
         onCollapse={handleOnCollapse} // TODO: set undefined when there is an empty state
         rows={
-          errorState || loadingState ? (
+          errorState || loadingState || noInput ? (
             [
               {
                 fullWidth: true,
@@ -235,8 +243,13 @@ const WorkloadRules = ({ workload }) => {
                     props: {
                       colSpan: WORKLOAD_RULES_COLUMNS.length + 1,
                     },
-                    title: <Loading />,
-                    // TODO: Empty state
+                    title: errorState ? (
+                      <NoWorkloadsRecsAvailable />
+                    ) : loadingState ? (
+                      <Loading />
+                    ) : (
+                      <NoRecsForWorkloadsDetails />
+                    ),
                   },
                 ],
               },


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-5519

https://www.sketch.com/s/46f6d8e3-a4d0-4249-9d57-e6a79b518a6d/a/9lZVpvn

https://www.sketch.com/s/46f6d8e3-a4d0-4249-9d57-e6a79b518a6d/a/P1Wm4yQ

How to run it locally:

Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock) or pull the latest changes
make build
can speed it up with make build -j 4 to run multiple jobs at once
make run
Test the mocked api curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
Run the app MOCK=true npm run start:proxy:beta
Workloads should load mocked data
Review the PR