### PR TITLE
fix(rhineng-6131): fixed a reset filters button on the workload table

### DIFF
--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -247,7 +247,7 @@ const WorkloadsListTable = ({
   ];
 
   const activeFiltersConfig = {
-    showDeleteButton: filtersApplied ? true : false,
+    showDeleteButton: filtersApplied,
     deleteTitle: 'Reset filters',
     filters: buildFilterChips(filters, WORKLOADS_TABLE_FILTER_CATEGORIES),
     onDelete: (_event, itemsToRemove, isAll) => {


### PR DESCRIPTION
Check the main workloads table. Try to change filters pages and limits. Reset filters button shouldn't appear unless there is a filter present


How to run it locally:

1. Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock) or pull the latest changes
2. make build
3. can speed it up with make build -j 4 to run multiple jobs at once
4. make run
5. Test the mocked api curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
6. Run the app MOCK=true npm run start:proxy:beta
7. Workloads should load mocked data
8. Review the PR