### PR TITLE
fix(rhineng-5493): breadcrumbs fix

### DIFF
--- a/src/Components/Breadcrumbs/Breadcrumbs.cy.js
+++ b/src/Components/Breadcrumbs/Breadcrumbs.cy.js
@@ -71,4 +71,36 @@ describe('breadcrumbs', () => {
     cy.get(BREADCRUMB_ITEM).eq(1).should('have.text', 'Cluster with issues');
     cy.get(BREADCRUMB_ITEM).eq(1).find('span').should('have.length', 1);
   });
+
+  it('renders breadcrumbs: single workloads details page', () => {
+    props = {
+      current: 'Cluster name 000000001 | Namespace name c1-94f525441c75',
+      workloads: true,
+    };
+    mount(
+      <MemoryRouter
+        initialEntries={[
+          '/openshift/insights/advisor/workloads/000000001/c1-94f525441c75?sort=-description',
+        ]}
+        initialIndex={0}
+      >
+        <IntlProvider locale="en">
+          <Breadcrumbs {...props} />
+        </IntlProvider>
+      </MemoryRouter>
+    );
+    cy.get(BREADCRUMB_ITEM).should('have.length', 2);
+    cy.get(BREADCRUMB_ITEM).eq(0).should('have.text', 'Advisor workloads');
+    cy.get(BREADCRUMB_ITEM)
+      .eq(0)
+      .find('a')
+      .should('have.attr', 'href', '/openshift/insights/advisor/workloads');
+    cy.get(BREADCRUMB_ITEM)
+      .eq(1)
+      .should(
+        'have.text',
+        'Cluster name 000000001 | Namespace name c1-94f525441c75'
+      );
+    cy.get(BREADCRUMB_ITEM).eq(1).find('span').should('have.length', 1);
+  });
 });

--- a/src/Components/Breadcrumbs/index.js
+++ b/src/Components/Breadcrumbs/index.js
@@ -7,7 +7,7 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
 import messages from '../../Messages';
 
-const Breadcrumbs = ({ current }) => {
+const Breadcrumbs = ({ current, workloads }) => {
   const intl = useIntl();
   const location = useLocation();
   const splitUrl = location.pathname.split('/');
@@ -16,7 +16,7 @@ const Breadcrumbs = ({ current }) => {
     <div>
       <Breadcrumb ouiaId="detail">
         <BreadcrumbItem className="breadcrumb-item">
-          <Link to={`..`} relative="path">
+          <Link to={workloads ? `../..` : `..`} relative="path">
             {`${intl.formatMessage(messages.insightsHeader)} ${splitUrl[4]}`}
           </Link>
         </BreadcrumbItem>
@@ -30,6 +30,7 @@ const Breadcrumbs = ({ current }) => {
 
 Breadcrumbs.propTypes = {
   current: PropTypes.string,
+  workloads: PropTypes.boolean,
 };
 
 export default Breadcrumbs;

--- a/src/Components/Workload/Workload.js
+++ b/src/Components/Workload/Workload.js
@@ -18,6 +18,7 @@ export const Workload = ({ workload, namespaceId, clusterId }) => {
                   ? `${workload.data.cluster.display_name} | ${workload.data.namespace.name}`
                   : `${clusterId} | ${namespaceId}`
               }
+              workloads="true"
             />
             <WorkloadsHeader />
           </FlexItem>


### PR DESCRIPTION
Breadcrumbs fix, because of the Double name for the workloads that contain BOTH cluster ID and Namespace ID - breadcrumbs component had to adjusted.
I wrote tests to check that it is fixed
https://issues.redhat.com/browse/RHINENG-5493