### PR TITLE
Fix workloads table empty state

### DIFF
--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -320,6 +320,15 @@ const NoRecsForWorkloadsDetails = () => {
   );
 };
 
+const NoMatchingWorkloads = () => {
+  return (
+    <MessageState
+      title={'No matching workloads found'}
+      text={'To continue, edit your filter settings and search again.'}
+    />
+  );
+};
+
 export {
   ErrorState,
   NoAffectedClusters,
@@ -336,4 +345,5 @@ export {
   NoWorkloadsAvailable,
   NoWorkloadsRecsAvailable,
   NoRecsForWorkloadsDetails,
+  NoMatchingWorkloads,
 };

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -75,11 +75,10 @@ const WorkloadsListTable = ({
     dispatch(updateWorkloadsListFilters(payload));
   const removeFilterParam = (param) =>
     _removeFilterParam(filters, updateFilters, param);
-  console.log(filteredRows, 'filteredRows');
 
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError;
-  const noMatch = rows.length > 0 || filteredRows.length === 0;
+  const noMatch = filteredRows.length === 0;
   const successState = isSuccess;
   const { search } = useLocation();
 

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -41,7 +41,7 @@ import {
 } from '../Common/Tables';
 import {
   ErrorState,
-  NoMatchingClusters,
+  NoMatchingWorkloads,
   NoRecsForWorkloads,
   NoWorkloadsAvailable,
 } from '../MessageState/EmptyStates';
@@ -75,10 +75,11 @@ const WorkloadsListTable = ({
     dispatch(updateWorkloadsListFilters(payload));
   const removeFilterParam = (param) =>
     _removeFilterParam(filters, updateFilters, param);
+  console.log(filteredRows, 'filteredRows');
 
   const loadingState = isUninitialized || isFetching || !rowsFiltered;
   const errorState = isError;
-  const noMatch = rows.length > 0 && filteredRows.length === 0;
+  const noMatch = rows.length > 0 || filteredRows.length === 0;
   const successState = isSuccess;
   const { search } = useLocation();
 
@@ -333,7 +334,7 @@ const WorkloadsListTable = ({
                     ) : loadingState ? (
                       <Loading />
                     ) : (
-                      <NoMatchingClusters />
+                      <NoMatchingWorkloads />
                     ),
                   },
                 ],


### PR DESCRIPTION
New empty state (I don't have mocks for it ready but we discussed it with Shanya personally)
Should appear in case when there are no search results
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/a5d8818d-130e-4d0d-a0e2-019ae0fa9333)
