### PR TITLE
fix(workloads rules): remove default sorting for workloads rules

### DIFF
--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -58,8 +58,8 @@ export const WORKLOADS_TABLE_INITIAL_STATE = {
 };
 
 export const WORKLOADS_RECS_TABLE_INITIAL_STATE = {
-  sortIndex: 1,
-  sortDirection: 'desc',
+  sortIndex: -1,
+  sortDirection: 'asc',
   description: '',
   total_risk: [],
   object_id: '',


### PR DESCRIPTION
remove default sorting for workloads rules

1. Clone [insights-results-aggregator-mock](https://github.com/RedHatInsights/insights-results-aggregator-mock) or pull the latest changes
2. make build
3. can speed it up with make build -j 4 to run multiple jobs at once
4. make run
5. Test the mocked api curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
6. Run the app MOCK=true npm run start:proxy:beta
7. Workloads should load mocked data
8. Review the PR