### PR TITLE
fix(workloads): fixing scrollbar and close button overlap

### DIFF
--- a/src/Components/ObjectsModal/ObjectsModal.js
+++ b/src/Components/ObjectsModal/ObjectsModal.js
@@ -10,6 +10,7 @@ const ObjectsModal = ({ isModalOpen, setIsModalOpen }) => {
       isOpen={isModalOpen}
       onClose={() => setIsModalOpen(false)}
       variant={'medium'}
+      title="Objects"
     >
       <ObjectsModalTable
         //objects={objects}

--- a/src/Components/ObjectsModalTable/ObjectsModalTable.js
+++ b/src/Components/ObjectsModalTable/ObjectsModalTable.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import { Title } from '@patternfly/react-core';
 import PrimaryToolbar from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import { ObjectsTableColumns } from '../../AppConstants';
 import PropTypes from 'prop-types';

--- a/src/Components/ObjectsModalTable/ObjectsModalTable.js
+++ b/src/Components/ObjectsModalTable/ObjectsModalTable.js
@@ -131,9 +131,6 @@ export const ObjectsModalTable = ({ objects }) => {
 
   return (
     <div id="objects-list-table">
-      <Title headingLevel="h1" ouiaId="page-header">
-        Objects
-      </Title>
       <PrimaryToolbar
         pagination={{
           page,


### PR DESCRIPTION
Previously:
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/045298b4-709f-49eb-b21b-39356eacd919)

After fix:
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/f847fa21-cd84-4c95-b7bc-d097946c6d4d)
