### PR TITLE
fix(workloads): add stack item to the button

### DIFF
--- a/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
+++ b/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
@@ -78,13 +78,16 @@ const ExpandedRulesDetails = ({ more_info, resolution, objects }) => {
               ))}
             </Tbody>
           </Table>
-          <Button
-            variant="link"
-            isInline
-            onClick={() => setObjectsModalOpen(true)}
-          >
-            View all objects
-          </Button>
+          <StackItem>
+            <Button
+              variant="link"
+              isInline
+              onClick={() => setObjectsModalOpen(true)}
+            >
+              View all objects
+            </Button>
+          </StackItem>
+
           <br />
           <CardHeader>
             <strong>Note:</strong>


### PR DESCRIPTION
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/2a6ad8e6-ca4d-4177-993d-587310d65edc)

Without using stack item the "View all objects" button was clickable on the whole width of the row.

How to test:
remove stack item and you will be able to click view all object button anywhere in the row