### PR TITLE
fix(RHINENG-7865): Workloads detail expanded recommendation icon has gap

### DIFF
--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -44,6 +44,7 @@ import {
   workloadsRulesRemoveFilterParam,
 } from '../../Utilities/Workloads';
 import { useLocation } from 'react-router-dom';
+import './WorkloadRules.scss';
 
 const WorkloadRules = ({ workload }) => {
   const dispatch = useDispatch();
@@ -191,6 +192,7 @@ const WorkloadRules = ({ workload }) => {
               ),
             },
           ],
+          fullWidth: true,
         },
       ]);
   };

--- a/src/Components/WorkloadRules/WorkloadRules.scss
+++ b/src/Components/WorkloadRules/WorkloadRules.scss
@@ -1,0 +1,85 @@
+@import '~@redhat-cloud-services/frontend-components-utilities/styles/_mixins';
+
+.ins-c-report-details {
+  &__cards-stack {
+    pre {
+      display: block;
+      color: var(--pf-global--Color--100);
+      word-break: break-all;
+      word-wrap: break-word;
+      background-color: var(--pf-global--BackgroundColor--light-200);
+      border: 1px solid var(--pf-global--BorderColor--100);
+      border-radius: 4px;
+      @include rem('padding', 10px);
+      @include rem('margin', (10px, 0));
+
+      code {
+        white-space: pre-wrap;
+      }
+    }
+
+    p,
+    ul,
+    ol,
+    li,
+    dl,
+    dt,
+    dd,
+    blockquote,
+    figure,
+    fieldset,
+    legend,
+    textarea,
+    iframe,
+    hr {
+      margin: revert;
+      padding: revert;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-family: var(--pf-global--FontFamily--heading--sans-serif);
+      line-height: 1.5;
+    }
+
+    h1 {
+      font-size: var(--pf-global--FontSize--2xl);
+      line-height: 1.3;
+    }
+    h2 {
+      font-size: var(--pf-global--FontSize--xl);
+    }
+    h3 {
+      font-size: var(--pf-global--FontSize--lg);
+    }
+    h4, h5, h6 {
+      font-size: var(--pf-global--FontSize--md);
+    }
+
+    .pf-c-list {
+      @include rem('margin', 5px 0);
+    }
+
+    table {
+      width: 100%;
+      @include rem('margin-top', 10px);
+
+      tr {
+        border-bottom: 1px solid var(--pf-global--BorderColor--300);
+      }
+
+      th,
+      td {
+        @include rem('padding', 8px);
+      }
+    }
+  }
+
+  &__icon {
+    margin-right: var(--pf-global--spacer--sm);
+  }
+}


### PR DESCRIPTION
[Jira ticket](https://issues.redhat.com/browse/RHINENG-7865)

Before
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/20592948/25be5d68-fcfe-4786-8ea7-dc376e0cf790)
After
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/20592948/a9100372-d7ca-4a37-8052-e535547c5030)
