### PR TITLE
fix(rhineng-7889): fixed a filter bug and wrote more tests

### DIFF
--- a/src/Components/Common/Tables.js
+++ b/src/Components/Common/Tables.js
@@ -318,27 +318,3 @@ export const passFilterWorkloads = (workloads, filters) => {
     }
   });
 };
-
-export const passFilterWorkloadsRecs = (recommendation, filters) => {
-  return Object.entries(filters).some(([filterKey, filterValue]) => {
-    console.log(filterKey, filterValue);
-    if (filterValue.length === 0) {
-      return false;
-    } else {
-      switch (filterKey) {
-        case 'description':
-          return recommendation.details
-            .toLowerCase()
-            .includes(filterValue.toLowerCase());
-        case 'object_id':
-          return recommendation.objects.some((obj) =>
-            obj.uid.toLowerCase().includes(filterValue.toLowerCase())
-          );
-        case 'total_risk':
-          return filterValue.includes(String(recommendation.total_risk));
-        default:
-          return false;
-      }
-    }
-  });
-};

--- a/src/Components/WorkloadRules/WorkloadRules.js
+++ b/src/Components/WorkloadRules/WorkloadRules.js
@@ -29,7 +29,6 @@ import {
   updateWorkloadsRecsListFilters,
 } from '../../Services/Filters';
 import {
-  passFilterWorkloadsRecs,
   translateSortParams,
   paramParser,
   updateSearchParams,
@@ -38,6 +37,7 @@ import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import {
   filtersAreApplied,
   flatMapRows,
+  passFilterWorkloadsRecs,
   pruneWorkloadsRulesFilters,
   sortWithSwitch,
   workloadsRulesAddFilterParam,

--- a/src/Components/WorkloadRules/WorkloadsRules.test.js
+++ b/src/Components/WorkloadRules/WorkloadsRules.test.js
@@ -6,6 +6,7 @@ import {
   sortWithSwitch,
   workloadsRulesRemoveFilterParam,
   workloadsRulesAddFilterParam,
+  passFilterWorkloadsRecs,
 } from '../../Utilities/Workloads';
 
 describe('capitalize function', () => {
@@ -231,5 +232,49 @@ describe('workloadsRulesAddFilterParam', () => {
       object_id: '123',
       total_risk: [],
     });
+  });
+});
+
+describe('passFilterWorkloadsRecs', () => {
+  const recommendation = {
+    details: 'Sample details',
+    objects: [{ uid: 'abc' }],
+    total_risk: 2,
+  };
+
+  it('should return true with empty filters', () => {
+    const filters = {};
+    const result = passFilterWorkloadsRecs(recommendation, filters);
+    expect(result).toBe(true);
+  });
+
+  it('should filter based on description', () => {
+    const filters = { description: 'sample' };
+    const result = passFilterWorkloadsRecs(recommendation, filters);
+    expect(result).toBe(true);
+  });
+
+  it('should filter based on object_id', () => {
+    const filters = { object_id: 'abc' };
+    const result = passFilterWorkloadsRecs(recommendation, filters);
+    expect(result).toBe(true);
+  });
+
+  it('should filter based on total_risk', () => {
+    const filters = { total_risk: ['2'] };
+    const result = passFilterWorkloadsRecs(recommendation, filters);
+    expect(result).toBe(true);
+  });
+
+  it('should return false with non-matching filters', () => {
+    const filters = { description: 'nonexistent', object_id: 'xyz' };
+    const result = passFilterWorkloadsRecs(recommendation, filters);
+    expect(result).toBe(false);
+  });
+
+  it('should handle empty string filters', () => {
+    const filters = { description: '' };
+    const result = passFilterWorkloadsRecs(recommendation, filters);
+    expect(result).toBe(true); // Empty string filter should be ignored
   });
 });

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -1,5 +1,5 @@
 import { SortByDirection } from '@patternfly/react-table';
-import _, { isEmpty } from 'lodash';
+import _ from 'lodash';
 
 export const SEVERITY_OPTIONS = [
   {
@@ -86,7 +86,7 @@ export const filtersAreApplied = (params) => {
   delete cleanedUpParams.offset;
   delete cleanedUpParams.limit;
   delete cleanedUpParams.sort;
-  return Object.values(cleanedUpParams).filter((value) => !isEmpty(value))
+  return Object.values(cleanedUpParams).filter((value) => !_.isEmpty(value))
     .length
     ? true
     : false;
@@ -226,3 +226,32 @@ export const workloadsRulesAddFilterParam = (
         ...{ [param]: values },
       })
     : workloadsRulesRemoveFilterParam(currentFilters, updateFilters, param);
+
+export const passFilterWorkloadsRecs = (recommendation, filters) => {
+  const cleanedUpFilters = _.omitBy(_.cloneDeep(filters), _.isEmpty);
+
+  return Object.entries(cleanedUpFilters).every(([filterKey, filterValue]) => {
+    switch (filterKey) {
+      case 'description':
+        return (
+          filterValue &&
+          recommendation.details
+            .toLowerCase()
+            .includes(filterValue.toLowerCase())
+        );
+      case 'object_id':
+        return (
+          filterValue &&
+          recommendation.objects.some((obj) =>
+            obj.uid.toLowerCase().includes(filterValue.toLowerCase())
+          )
+        );
+      case 'total_risk':
+        return (
+          filterValue && filterValue.includes(String(recommendation.total_risk))
+        );
+      default:
+        return true;
+    }
+  });
+};


### PR DESCRIPTION
I had to rethink how I map filters for the workload details.
I made a function using lodash methods to omit any empty filters and create a new object named cleanedUpFilters
After it is created we can check if we have matching recommendations based on the new object pairs of filterKey and filterValue.

I added basic tests to check that it works as expected.
Also, I moved this function to the Workloads utils file