### PR TITLE
fix(rhineng-8046): objects modal compact table

### DIFF
--- a/src/Components/ObjectsModalTable/ObjectsModalTable.js
+++ b/src/Components/ObjectsModalTable/ObjectsModalTable.js
@@ -147,7 +147,7 @@ export const ObjectsModalTable = ({ objects }) => {
         <Loading />
       ) : preparedRows ? (
         <div>
-          <Table aria-label="Cell widths">
+          <Table aria-label="Cell widths" variant="compact">
             <Thead>
               <Tr>
                 <Th width={60}>{ObjectsTableColumns.object}</Th>


### PR DESCRIPTION
Table should be compact 
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/5334cadc-4dc1-4e84-b0d7-1da045ab6452)

sketch 
https://www.sketch.com/s/46f6d8e3-a4d0-4249-9d57-e6a79b518a6d/a/dgb4Lp2