### PR TITLE
feat(rhineng-7974): severity link with path and filters

### DIFF
--- a/src/Components/ShieldSet.js
+++ b/src/Components/ShieldSet.js
@@ -5,15 +5,12 @@ import { Link } from 'react-router-dom';
 import { Tooltip } from '@patternfly/react-core';
 import { SEVERITY_OPTIONS, remappingSeverity } from '../Utilities/Workloads';
 
-const ShieldSet = (hits_by_severity) => {
+const ShieldSet = ({ hits_by_severity, basePath }) => {
   const DISABLED_COLOR = 'var(--pf-global--disabled-color--200)';
-  const severitiesRemapped = remappingSeverity(
-    hits_by_severity.hits_by_severity,
-    'label'
-  );
+  const severitiesRemapped = remappingSeverity(hits_by_severity, 'label');
   return (
     <div className="shield-set">
-      {SEVERITY_OPTIONS.map((severityOption) => (
+      {SEVERITY_OPTIONS.map((severityOption, index) => (
         <Tooltip
           key={severityOption.value}
           content={`${severityOption.label} severity`}
@@ -27,7 +24,7 @@ const ShieldSet = (hits_by_severity) => {
             ) : (
               <Link
                 key={severityOption.value}
-                to={`?severity=${severityOption.value}`}
+                to={`${basePath}?total_risk=${SEVERITY_OPTIONS[index].indexNumber}`}
                 className="nowrap"
               >
                 <SecurityIcon style={{ color: severityOption.iconColor }} />
@@ -48,6 +45,7 @@ ShieldSet.propTypes = {
     low: PropTypes.number,
   }).isRequired,
   linkTo: PropTypes.string,
+  basePath: PropTypes.string,
 };
 
 export default ShieldSet;

--- a/src/Components/WorkloadsListTable/WorkloadsListTable.js
+++ b/src/Components/WorkloadsListTable/WorkloadsListTable.js
@@ -196,7 +196,10 @@ const WorkloadsListTable = ({
           </span>,
           item.metadata.recommendations,
           <span key={index}>
-            <ShieldSet hits_by_severity={item.metadata.hits_by_severity} />
+            <ShieldSet
+              hits_by_severity={item.metadata.hits_by_severity}
+              basePath={`${BASE_PATH}/workloads/${item.cluster.uuid}/${item.namespace.uuid}`}
+            />
           </span>,
           item.metadata.objects,
           <span key={index}>

--- a/src/Utilities/Workloads.js
+++ b/src/Utilities/Workloads.js
@@ -8,6 +8,7 @@ export const SEVERITY_OPTIONS = [
     iconColor: 'var(--pf-global--danger-color--100)',
     textColor: 'var(--pf-global--danger-color--100)',
     hasIcon: true,
+    indexNumber: 4,
   },
   {
     value: 'important',
@@ -15,6 +16,7 @@ export const SEVERITY_OPTIONS = [
     iconColor: 'var(--pf-global--palette--orange-300)',
     textColor: 'var(--pf-global--palette--orange-400)',
     hasIcon: true,
+    indexNumber: 3,
   },
   {
     value: 'moderate',
@@ -22,6 +24,7 @@ export const SEVERITY_OPTIONS = [
     iconColor: 'var(--pf-global--warning-color--100)',
     textColor: 'var(--pf-global--warning-color--200)',
     hasIcon: true,
+    indexNumber: 2,
   },
   {
     value: 'low',
@@ -29,10 +32,7 @@ export const SEVERITY_OPTIONS = [
     iconColor: 'var(--pf-global--Color--200)',
     textColor: 'var(--pf-global--default-color--300)',
     hasIcon: true,
-  },
-  {
-    value: 'none',
-    label: 'Unknown',
+    indexNumber: 1,
   },
 ];
 


### PR DESCRIPTION
Severity links now lead to the workload details with the applied filter.
Critical severity equals to critical filter applied and same for the rest of severities
