### PR TITLE
feat(RHINENG-7886): add a beta check for the prod preview release

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -12,6 +12,7 @@ import useFeatureFlag, {
   WORKLOADS_ENABLE_FLAG,
 } from './Utilities/useFeatureFlag';
 import { ErrorState } from './Components/MessageState/EmptyStates';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const Cluster = lazy(() =>
   import(/* webpackChunkName: "ClusterDetails" */ './Components/Cluster')
@@ -41,6 +42,8 @@ export const BASE_PATH = '/openshift/insights/advisor';
 
 export const AppRoutes = () => {
   const workloadsEnabled = useFeatureFlag(WORKLOADS_ENABLE_FLAG);
+  const chrome = useChrome();
+  const beta = chrome.isBeta();
   return (
     <Suspense
       fallback={
@@ -97,7 +100,7 @@ export const AppRoutes = () => {
         <Route
           path="/workloads"
           element={
-            workloadsEnabled ? (
+            workloadsEnabled && beta ? (
               <WorkloadsList
                 /**
                  * Generate random `key` to force component re-render,
@@ -112,7 +115,7 @@ export const AppRoutes = () => {
         <Route
           path="/workloads/:clusterId/:namespaceId"
           element={
-            workloadsEnabled ? (
+            workloadsEnabled && beta ? (
               <Workload
                 /**
                  * Generate random `key` to force component re-render,

--- a/src/Utilities/useFeatureFlag.js
+++ b/src/Utilities/useFeatureFlag.js
@@ -23,7 +23,5 @@ export const useUpdateRisksFeatureFlag = () => {
 
 export const useWorkloadsFeatureFlag = () => {
   const workloadsEnabled = useFeatureFlag(WORKLOADS_ENABLE_FLAG);
-  const chrome = useChrome();
-
-  return chrome.isBeta() || workloadsEnabled;
+  return workloadsEnabled;
 };


### PR DESCRIPTION
To make a production preview release possible I need to add a beta check for the workload routes. That would allow us to turn the feature flag in production ON and serve workloads only in the production preview
I already prepared a PR for the chrome navigation https://github.com/RedHatInsights/chrome-service-backend/pull/403

beta off
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/d086f6ac-1b67-41fe-b1cc-f106955f6655)
beta on 
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/45ecca7e-3842-4a17-9580-1c8d0b7a2360)
