### PR TITLE
chore: Disable semantic-release comments and labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,15 @@
     },
     "prepare": [],
     "publish": [
-      "@semantic-release/github"
+      [
+        "@semantic-release/github",
+        {
+          "successComment": false,
+          "failComment": false,
+          "labels": false,
+          "releasedLabels": false
+        }
+      ]
     ]
   },
   "repository": "git@github.com:RedHatInsights/ocp-advisor-frontend.git",


### PR DESCRIPTION
This should silence the semantic-release bot so that it doesn't add any released labels or comments to PRs which are misleading.

Docs: https://github.com/semantic-release/github, https://github.com/semantic-release/semantic-release/blob/master/docs/usage/plugins.md#plugin-options-configuration.