### PR TITLE
fix(RHINENG-5526): More conditional rendering for expanded details and fixing component structure

### DIFF
--- a/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
+++ b/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
@@ -62,7 +62,6 @@ const ExpandedRulesDetails = ({
               </CardBody>
             </Card>
           </StackItem>
-
           {objectsArePresent && (
             <React.Fragment>
               <Divider />
@@ -113,7 +112,6 @@ const ExpandedRulesDetails = ({
               </Button>
             </StackItem>
           )}
-          <br />
           {!namespaceName && (
             <React.Fragment>
               <CardHeader>

--- a/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
+++ b/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
@@ -9,7 +9,10 @@ import {
   Card,
   CardBody,
   CardHeader,
+  ClipboardCopyButton,
   CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
   Divider,
   Icon,
   Stack,
@@ -21,8 +24,53 @@ import TemplateProcessor from '@redhat-cloud-services/frontend-components-adviso
 import ObjectsModal from '../ObjectsModal/ObjectsModal';
 import { ObjectsTableColumns } from '../../AppConstants';
 
-const code = `oc get namespace -o jsonpath={range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\n"}{end}
-  oc -n <namespace> get <resourceKind> -o jsonpath={range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\n"}{end}`;
+const OpenshiftCodeBlocks = () => {
+  const code1 = `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{"\\t"}{.metadata.uid}{"\\n"}{end}'`;
+
+  const code2 = `oc -n <namespace> get <resourceKind> -o jsonpath='{range .items[*]}{.metadata.name}{"\\t"}{.metadata.uid}{"\\n"}{end}'`;
+
+  const clipboardCopyFunc = (event, text) => {
+    navigator.clipboard.writeText(text.toString());
+  };
+
+  const onClick = (event, text) => {
+    clipboardCopyFunc(event, text);
+    setCopied(true);
+  };
+
+  const [copied, setCopied] = React.useState(false);
+
+  const action = (code) => (
+    <React.Fragment>
+      <CodeBlockAction>
+        <ClipboardCopyButton
+          id="basic-copy-button"
+          textId="code-content"
+          aria-label="Copy to clipboard"
+          onClick={(e) => onClick(e, code)}
+          exitDelay={copied ? 1500 : 600}
+          maxWidth="110px"
+          variant="plain"
+          onTooltipHidden={() => setCopied(false)}
+        >
+          {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
+        </ClipboardCopyButton>
+      </CodeBlockAction>
+    </React.Fragment>
+  );
+
+  return (
+    <>
+      <CodeBlock
+        actions={action(code1.concat('\n', code2))}
+        className="pf-v5-u-mt-md"
+      >
+        <CodeBlockCode>{code1}</CodeBlockCode>
+        <CodeBlockCode>{code2}</CodeBlockCode>
+      </CodeBlock>
+    </>
+  );
+};
 
 const ExpandedRulesDetails = ({
   more_info,
@@ -33,7 +81,6 @@ const ExpandedRulesDetails = ({
   extra_data,
 }) => {
   const objectsArePresent = Array.isArray(objects) && objects.length > 0;
-  console.log(objects);
   const moreInfoIsPresent = more_info.length > 0 ? true : false;
   const [objectsModalOpen, setObjectsModalOpen] = useState(false);
   return (
@@ -128,9 +175,7 @@ const ExpandedRulesDetails = ({
                 and resources are identified by their UIDs instead. You can use
                 in-cluster commands like the ones below to translate UIDs of
                 affected resources to their names.
-                <CodeBlock>
-                  <TemplateProcessor template={code} definitions={extra_data} />
-                </CodeBlock>
+                <OpenshiftCodeBlocks />
               </CardBody>
             </React.Fragment>
           )}

--- a/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
+++ b/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
@@ -78,39 +78,44 @@ const ExpandedRulesDetails = ({
                       template={resolution}
                       definitions={extra_data}
                     />
+                    <Table
+                      borders={'compactBorderless'}
+                      aria-label="Objects table"
+                    >
+                      <Thead>
+                        <Tr>
+                          <Th modifier="fitContent">
+                            {ObjectsTableColumns.object}
+                          </Th>
+                          <Th modifier="fitContent">
+                            {ObjectsTableColumns.kind}
+                          </Th>
+                        </Tr>
+                      </Thead>
+                      <Tbody>
+                        {objects.slice(0, 3).map((object, key) => (
+                          <Tr key={key}>
+                            <Td dataLabel={ObjectsTableColumns.object}>
+                              {object.uid}
+                            </Td>
+                            <Td dataLabel={ObjectsTableColumns.kind}>
+                              {object.kind}
+                            </Td>
+                          </Tr>
+                        ))}
+                      </Tbody>
+                    </Table>
+                    <Button
+                      variant="link"
+                      isInline
+                      onClick={() => setObjectsModalOpen(true)}
+                    >
+                      View all objects
+                    </Button>
                   </CardBody>
                 </Card>
               </StackItem>
             </React.Fragment>
-          )}
-          {objectsArePresent && (
-            <Table borders={'compactBorderless'} aria-label="Objects table">
-              <Thead>
-                <Tr>
-                  <Th modifier="fitContent">{ObjectsTableColumns.object}</Th>
-                  <Th modifier="fitContent">{ObjectsTableColumns.kind}</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {objects.slice(0, 3).map((object, key) => (
-                  <Tr key={key}>
-                    <Td dataLabel={ObjectsTableColumns.object}>{object.uid}</Td>
-                    <Td dataLabel={ObjectsTableColumns.kind}>{object.kind}</Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          )}
-          {objectsArePresent && (
-            <StackItem>
-              <Button
-                variant="link"
-                isInline
-                onClick={() => setObjectsModalOpen(true)}
-              >
-                View all objects
-              </Button>
-            </StackItem>
           )}
           {!namespaceName && (
             <React.Fragment>

--- a/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
+++ b/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
@@ -33,6 +33,8 @@ const ExpandedRulesDetails = ({
   extra_data,
 }) => {
   const objectsArePresent = Array.isArray(objects) && objects.length > 0;
+  console.log(objects);
+  const moreInfoIsPresent = more_info.length > 0 ? true : false;
   const [objectsModalOpen, setObjectsModalOpen] = useState(false);
   return (
     <Card className="ins-c-report-details" style={{ boxShadow: 'none' }}>
@@ -60,23 +62,28 @@ const ExpandedRulesDetails = ({
               </CardBody>
             </Card>
           </StackItem>
-          <Divider />
-          <StackItem>
-            <Card isCompact isPlain>
-              <CardHeader>
-                <Icon>
-                  <ThumbsUpIcon className="ins-c-report-details__icon" />
-                </Icon>
-                <strong>Steps to resolve</strong>
-              </CardHeader>
-              <CardBody>
-                <TemplateProcessor
-                  template={resolution}
-                  definitions={extra_data}
-                />
-              </CardBody>
-            </Card>
-          </StackItem>
+
+          {objectsArePresent && (
+            <React.Fragment>
+              <Divider />
+              <StackItem>
+                <Card isCompact isPlain>
+                  <CardHeader>
+                    <Icon>
+                      <ThumbsUpIcon className="ins-c-report-details__icon" />
+                    </Icon>
+                    <strong>Steps to resolve</strong>
+                  </CardHeader>
+                  <CardBody>
+                    <TemplateProcessor
+                      template={resolution}
+                      definitions={extra_data}
+                    />
+                  </CardBody>
+                </Card>
+              </StackItem>
+            </React.Fragment>
+          )}
           {objectsArePresent && (
             <Table borders={'compactBorderless'} aria-label="Objects table">
               <Thead>
@@ -124,25 +131,27 @@ const ExpandedRulesDetails = ({
               </CardBody>
             </React.Fragment>
           )}
-          <React.Fragment>
-            <Divider />
-            <StackItem>
-              <Card isCompact isPlain>
-                <CardHeader>
-                  <Icon>
-                    <InfoCircleIcon className="ins-c-report-details__icon" />
-                  </Icon>
-                  <strong>Additional info</strong>
-                </CardHeader>
-                <CardBody>
-                  <TemplateProcessor
-                    template={more_info}
-                    definitions={extra_data}
-                  />
-                </CardBody>
-              </Card>
-            </StackItem>
-          </React.Fragment>
+          {moreInfoIsPresent && (
+            <React.Fragment>
+              <Divider />
+              <StackItem>
+                <Card isCompact isPlain>
+                  <CardHeader>
+                    <Icon>
+                      <InfoCircleIcon className="ins-c-report-details__icon" />
+                    </Icon>
+                    <strong>Additional info</strong>
+                  </CardHeader>
+                  <CardBody>
+                    <TemplateProcessor
+                      template={more_info}
+                      definitions={extra_data}
+                    />
+                  </CardBody>
+                </Card>
+              </StackItem>
+            </React.Fragment>
+          )}
         </Stack>
       </CardBody>
     </Card>


### PR DESCRIPTION
Mocks:
https://www.sketch.com/s/46f6d8e3-a4d0-4249-9d57-e6a79b518a6d/a/j4Pa8La
Added a check to render Additional info only in case when more info is present

restructured Steps to the Resolve section. The table was outside the "card" component. So I made it one card component and one Stack Item so it wouldn't have issues with margins

Before
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/255bb602-4135-4d56-afc3-27f494bf801f)

After
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/7d4614d6-160e-4ad0-8c1a-c7bd5f0b9fc8)

I added codeblock component from Alex PR to this PR, its faster that way and we won't have to solve conflicts
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/c78ed271-ab86-4228-98e1-8599a35452a6)
