### PR TITLE
fix(rhineng-5526): moving note text into header to align with mocks

### DIFF
--- a/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
+++ b/src/Components/ExpandedRulesDetails.js/ExpandedRulesDetails.js
@@ -167,14 +167,13 @@ const ExpandedRulesDetails = ({
           {!namespaceName && (
             <React.Fragment>
               <CardHeader>
-                <strong>Note:</strong>
+                <strong>Note: </strong>Red Hat avoids gathering and processing
+                namespace and resource names as these may reveal confidential
+                information. Namespaces and resources are identified by their
+                UIDs instead. You can use in-cluster commands like the ones
+                below to translate UIDs of affected resources to their names.
               </CardHeader>
               <CardBody>
-                Red Hat avoids gathering and processing namespace and resource
-                names as these may reveal confidential information. Namespaces
-                and resources are identified by their UIDs instead. You can use
-                in-cluster commands like the ones below to translate UIDs of
-                affected resources to their names.
                 <OpenshiftCodeBlocks />
               </CardBody>
             </React.Fragment>


### PR DESCRIPTION
Note: 
should be inside the text message and not separate
like on mocks
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/62722417/509af90a-a65b-47bb-aedf-a0eed0cd3ab4)
