### PR TITLE
fix(RHINENG-8253): Update risk label condition

### DIFF
--- a/config/overrideChrome.js
+++ b/config/overrideChrome.js
@@ -4,4 +4,19 @@ export default () => ({
   analytics: {
     track: () => fetch('/analytics/track'),
   },
+  auth: {
+    getUser: () => Promise.resolve(true),
+    logout: () => Promise.resolve(true),
+  },
+});
+export const useChrome = () => ({
+  updateDocumentTitle: () => undefined,
+  isBeta: () => false,
+  analytics: {
+    track: () => fetch('/analytics/track'),
+  },
+  auth: {
+    getUser: () => Promise.resolve(true),
+    logout: () => Promise.resolve(true),
+  },
 });

--- a/cypress/fixtures/api/insights-results-aggregator/v2/upgrade-risks-prediction.json
+++ b/cypress/fixtures/api/insights-results-aggregator/v2/upgrade-risks-prediction.json
@@ -4,7 +4,7 @@
       "cluster_id": "e488c993-821c-4915-bd08-5a51ed7aa3a2",
       "last_checked_at": "2011-15-04T00:05:23Z",
       "prediction_status": "ok",
-      "upgrade_recommended": true,
+      "upgrade_recommended": false,
       "upgrade_risks_predictors": {
         "alerts": [
           {

--- a/cypress/utils/interceptors.js
+++ b/cypress/utils/interceptors.js
@@ -212,7 +212,7 @@ export const clustersUpdateRisksInterceptors = {
           });
         });
       }
-    );
+    ).as('clustersUpdateRisksOKOne');
   },
   'successful, two labels': () => {
     cy.intercept(
@@ -239,7 +239,7 @@ export const clustersUpdateRisksInterceptors = {
           });
         });
       }
-    );
+    ).as('clustersUpdateRisksOKTwo');
   },
   'successful, no labels': () => {
     cy.intercept(
@@ -257,35 +257,41 @@ export const clustersUpdateRisksInterceptors = {
           });
         });
       }
-    );
+    ).as('clustersUpdateRisksOKNoLabels');
   },
   'error, status not ok': () =>
-    cy.intercept(
-      'POST',
-      /\/api\/insights-results-aggregator\/v2\/upgrade-risks-prediction/,
-      {
-        statusCode: 200,
-        body: {
-          status: 'not ok',
-        },
-      }
-    ),
+    cy
+      .intercept(
+        'POST',
+        /\/api\/insights-results-aggregator\/v2\/upgrade-risks-prediction/,
+        {
+          statusCode: 200,
+          body: {
+            status: 'not ok',
+          },
+        }
+      )
+      .as('clustersUpdateRisksNotOk'),
   'error, not found': () =>
-    cy.intercept(
-      'POST',
-      /\/api\/insights-results-aggregator\/v2\/upgrade-risks-prediction/,
-      {
-        statusCode: 404,
-      }
-    ),
+    cy
+      .intercept(
+        'POST',
+        /\/api\/insights-results-aggregator\/v2\/upgrade-risks-prediction/,
+        {
+          statusCode: 404,
+        }
+      )
+      .as('clustersUpdateRisks404'),
   'error, other': () =>
-    cy.intercept(
-      'POST',
-      /\/api\/insights-results-aggregator\/v2\/upgrade-risks-prediction/,
-      {
-        statusCode: 500,
-      }
-    ),
+    cy
+      .intercept(
+        'POST',
+        /\/api\/insights-results-aggregator\/v2\/upgrade-risks-prediction/,
+        {
+          statusCode: 500,
+        }
+      )
+      .as('clustersUpdateRisks500'),
   'long responding': () =>
     cy
       .intercept(

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@redhat-cloud-services/frontend-components-charts": "^3.2.6",
         "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
         "@redhat-cloud-services/frontend-components-translations": "^3.2.7",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.7",
+        "@redhat-cloud-services/frontend-components-utilities": "^4.0.9",
         "@reduxjs/toolkit": "^2.2.0",
         "@unleash/proxy-client-react": "^4.1.2",
         "axios": "^1.6.7",
@@ -4867,23 +4867,23 @@
       "peer": true
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.7.tgz",
-      "integrity": "sha512-Mr0u1rThsspet0SkR12mQRYO2xbA4zKCxSpHs/QKLlSIgQRKqVzmdf7J2SSXGXJJ9FeSE2wXJdI8a2F9TVVQnQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.9.tgz",
+      "integrity": "sha512-OHFrmsKqg5vaZHBr/cC/4bq6lT329dMhLDZzXYACiVavASRlmim2ZWVmfjZadkwozRqwYX85YC6GAYsN389rxQ==",
       "dependencies": {
         "@redhat-cloud-services/rbac-client": "^1.0.100",
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
         "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.28.0",
+        "axios": "^0.28.1",
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
+        "p-all": "^5.0.0",
         "react-content-loader": "^6.2.0"
       },
       "peerDependencies": {
         "@patternfly/react-core": "^5.0.0",
         "@patternfly/react-table": "^5.0.0",
-        "cypress": ">=12.0.0 < 14.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": ">=7.0.0",
@@ -4891,9 +4891,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -22425,6 +22425,31 @@
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs="
     },
+    "node_modules/p-all": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.0.tgz",
+      "integrity": "sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==",
+      "dependencies": {
+        "p-map": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-all/node_modules/p-map": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -31859,24 +31884,25 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.7.tgz",
-      "integrity": "sha512-Mr0u1rThsspet0SkR12mQRYO2xbA4zKCxSpHs/QKLlSIgQRKqVzmdf7J2SSXGXJJ9FeSE2wXJdI8a2F9TVVQnQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.9.tgz",
+      "integrity": "sha512-OHFrmsKqg5vaZHBr/cC/4bq6lT329dMhLDZzXYACiVavASRlmim2ZWVmfjZadkwozRqwYX85YC6GAYsN389rxQ==",
       "requires": {
         "@redhat-cloud-services/rbac-client": "^1.0.100",
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
         "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.28.0",
+        "axios": "^0.28.1",
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
+        "p-all": "^5.0.0",
         "react-content-loader": "^6.2.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-          "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+          "version": "0.28.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+          "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
           "requires": {
             "follow-redirects": "^1.15.0",
             "form-data": "^4.0.0",
@@ -44893,6 +44919,21 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs="
+    },
+    "p-all": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.0.tgz",
+      "integrity": "sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==",
+      "requires": {
+        "p-map": "^6.0.0"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+          "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw=="
+        }
+      }
     },
     "p-each-series": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@redhat-cloud-services/frontend-components-charts": "^3.2.6",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-translations": "^3.2.7",
-    "@redhat-cloud-services/frontend-components-utilities": "^4.0.7",
+    "@redhat-cloud-services/frontend-components-utilities": "^4.0.9",
     "@reduxjs/toolkit": "^2.2.0",
     "@unleash/proxy-client-react": "^4.1.2",
     "axios": "^1.6.7",

--- a/src/Components/ClustersListTable/ClustersListTable.cy.js
+++ b/src/Components/ClustersListTable/ClustersListTable.cy.js
@@ -536,6 +536,7 @@ describe('clusters list table', () => {
   });
 
   it('names of rows are links', () => {
+    cy.get('[data-ouia-component-id=loading-skeleton]').should('not.exist');
     cy.get(TBODY)
       .children()
       .each(($el, index) => {
@@ -549,6 +550,7 @@ describe('clusters list table', () => {
   });
 
   it('total risk hits are mapped correctly', () => {
+    cy.get('[data-ouia-component-id=loading-skeleton]').should('not.exist');
     cy.get('table')
       .find(TBODY)
       .find(ROW)
@@ -708,8 +710,9 @@ describe('update risk', () => {
     });
 
     it("don't block table rendering on error", () => {
+      cy.wait('@clustersUpdateRisksNotOk');
       cy.ouiaId('loading-skeleton').should('not.exist');
-      expect(filterData()).to.have.length.gte(1);
+      checkRowCounts(lessClusters.meta.count);
     });
   });
 
@@ -720,8 +723,9 @@ describe('update risk', () => {
     });
 
     it("don't block table rendering on error", () => {
+      cy.wait('@clustersUpdateRisks404');
       cy.ouiaId('loading-skeleton').should('not.exist');
-      expect(filterData()).to.have.length.gte(1);
+      checkRowCounts(lessClusters.meta.count);
     });
   });
 
@@ -732,8 +736,9 @@ describe('update risk', () => {
     });
 
     it("don't block table rendering on error", () => {
+      cy.wait('@clustersUpdateRisks500');
       cy.ouiaId('loading-skeleton').should('not.exist');
-      expect(filterData()).to.have.length.gte(1);
+      checkRowCounts(lessClusters.meta.count);
     });
   });
 
@@ -746,7 +751,7 @@ describe('update risk', () => {
     it("don't block table rendering on ", () => {
       cy.wait('@clustersUpdateRisksLong');
       cy.ouiaId('loading-skeleton').should('not.exist');
-      expect(filterData()).to.have.length.gte(1);
+      checkRowCounts(lessClusters.meta.count);
     });
   });
 });

--- a/src/Services/SmartProxy.js
+++ b/src/Services/SmartProxy.js
@@ -47,15 +47,6 @@ export const SmartProxyApi = createApi({
       query: ({ namespaceId, clusterId }) =>
         `v2/namespaces/dvo/${namespaceId}/cluster/${clusterId}`,
     }),
-    getClustersUpgradeRisks: builder.query({
-      query: ({ clusters }) => ({
-        url: `v2/upgrade-risks-prediction`,
-        method: 'post',
-        body: {
-          clusters,
-        },
-      }),
-    }),
   }),
 });
 
@@ -76,6 +67,4 @@ export const {
   useGetUpdateRisksQuery,
   useGetWorkloadsQuery,
   useGetWorkloadByIdQuery,
-  useGetClustersUpgradeRisksQuery,
-  useLazyGetClustersUpgradeRisksQuery,
 } = SmartProxyApi;


### PR DESCRIPTION
[RHINENG-8253](https://issues.redhat.com/browse/RHINENG-8253)

There was a miscommunication when the `Update risk` label should be displayed

When the `upgrade-risks-prediction` endpoint returns a prediction where `"upgrade_recommended": false`, then we display the `Update risk` label for that cluster.

How to test:
1. Run the app in prod beta `npm run start`, select prod, then beta
2. Go to Clusters
3. There should be a system which has the label
![image](https://github.com/RedHatInsights/ocp-advisor-frontend/assets/20592948/0de7df34-8129-4ad3-9c47-540c84475d0f)

4. Verify it's the correct system by checking the endpoint