### PR TITLE
fix(RHINENG-8615): Fix "View ${n} affected clusters" link missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2270,6 +2270,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
       "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+      "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2298,6 +2299,7 @@
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
       "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -10258,6 +10260,7 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.4.0.tgz",
       "integrity": "sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
@@ -10315,6 +10318,7 @@
       "version": "18.19.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
       "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -10323,6 +10327,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -10337,6 +10342,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -10352,6 +10358,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10363,6 +10370,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -10373,12 +10381,14 @@
     "node_modules/cypress/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/cypress/node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10387,6 +10397,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10395,6 +10406,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13131,6 +13143,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -27542,7 +27555,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -30382,6 +30396,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
       "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -30407,6 +30422,7 @@
           "version": "6.10.4",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
           "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+          "dev": true,
           "requires": {
             "side-channel": "^1.0.4"
           }
@@ -36503,6 +36519,7 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.4.0.tgz",
       "integrity": "sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==",
+      "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
@@ -36553,6 +36570,7 @@
           "version": "18.19.26",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
           "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
+          "dev": true,
           "requires": {
             "undici-types": "~5.26.4"
           }
@@ -36561,6 +36579,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -36569,6 +36588,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -36578,6 +36598,7 @@
               "version": "7.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -36588,6 +36609,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -36595,22 +36617,26 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -38707,6 +38733,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -49161,7 +49188,8 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/src/Components/RecsListTable/RecsListTable.cy.js
+++ b/src/Components/RecsListTable/RecsListTable.cy.js
@@ -53,6 +53,7 @@ import {
   removeAllChips,
   urlParamConvert,
   checkEmptyState,
+  TABLE_ROW,
 } from '@redhat-cloud-services/frontend-components-utilities';
 
 import { SORTING_ORDERS } from '../../../cypress/utils/globals';
@@ -254,6 +255,14 @@ describe('data', () => {
   it('at least one recommendation in default list has more than 1 cluster hit', () => {
     expect(
       _.filter(filterData(), (it) => it.impacted_clusters_count > 1)
+    ).to.have.length.gte(1);
+  });
+  it('at least one rule has no affecting clutsers', () => {
+    expect(
+      filterData({
+        impacting: ['None'],
+      }),
+      (it) => it.impacted_clusters_count === 0
     ).to.have.length.gte(1);
   });
   it('at least one recommendation in default list has resolution risk set to non 0 value', () => {
@@ -704,6 +713,29 @@ describe('successful non-empty recommendations list table', () => {
         .eq(0)
         .find('.ins-c-rule-details__risk-of-ch-label')
         .should('have.text', 'High');
+    });
+
+    it('view affected link is present for rules affecting at least one cluster', () => {
+      cy.getRowByName(
+        'Super atomic nuclear cluster on the brink of the world destruction'
+      )
+        .find('[aria-label="Details"]')
+        .click();
+      cy.get(EXPANDABLES)
+        .first()
+        .contains(/View [\d\w,]* affected clusters/);
+    });
+
+    it('view affected link is missing for non-affecting rules', () => {
+      removeAllChips();
+      filterApply({
+        impacting: ['None'],
+      });
+      cy.get(TABLE_ROW).first().find('[aria-label="Details"]').click();
+      cy.get(EXPANDABLES)
+        .first()
+        .contains(/View [\d\w,]* affected clusters/)
+        .should('not.exist');
     });
   });
 

--- a/src/Components/RecsListTable/RecsListTable.js
+++ b/src/Components/RecsListTable/RecsListTable.js
@@ -265,8 +265,20 @@ const RecsListTable = ({ query }) => {
                       product={AdvisorProduct.ocp}
                       rule={adjustOCPRule(value)}
                       isDetailsPage={false}
-                      showViewAffected
-                      linkComponent={Link}
+                      {...(value.impacted_clusters_count > 0
+                        ? {
+                            ViewAffectedLink: (
+                              <Link to={value.rule_id}>
+                                {intl.formatMessage(
+                                  messages.viewAffectedClusters,
+                                  {
+                                    clusters: value.impacted_clusters_count,
+                                  }
+                                )}
+                              </Link>
+                            ),
+                          }
+                        : {})}
                       {...(inRange(value?.resolution_risk, 1, 5) // resolution risk can be 0 (not defined for particular rule)
                         ? {
                             resolutionRisk: value?.resolution_risk,


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-8615.

This replaces the deprecated "showViewAffected" flag and passes "ViewAffectedLink" node instead. This fixes the link missing in the expanded rule details.

## How to test

Go to /openshift/insights/recommendations, makes sure you can see "View affected clusters" in the expanded details for impacting recommendations. The link must not appear for non-impacting rules. 