### PR TITLE
fix: Update risk label second feature flag

### DIFF
--- a/cypress/utils/interceptors.js
+++ b/cypress/utils/interceptors.js
@@ -197,6 +197,14 @@ export const featureFlagsInterceptors = {
               enabled: true,
             },
           },
+          {
+            name: 'ocp-advisor-ui-upgrade-risks',
+            enabled: true,
+            variant: {
+              name: 'disabled',
+              enabled: true,
+            },
+          },
         ],
       },
     }).as('upgradeRisksFlag');
@@ -208,6 +216,39 @@ export const featureFlagsInterceptors = {
         toggles: [
           {
             name: 'ocp-advisor.upgrade-risks.enable-in-stable',
+            enabled: true,
+            variant: {
+              name: 'disabled',
+              enabled: true,
+            },
+          },
+          {
+            name: 'ocp-advisor-ui-upgrade-risks',
+            enabled: false,
+            variant: {
+              name: 'disabled',
+              enabled: true,
+            },
+          },
+        ],
+      },
+    }).as('upgradeRisksFlagDisabled');
+  },
+  upgradeRisksDisabled2: () => {
+    cy.intercept('/feature_flags*', {
+      statusCode: 200,
+      body: {
+        toggles: [
+          {
+            name: 'ocp-advisor.upgrade-risks.enable-in-stable',
+            enabled: false,
+            variant: {
+              name: 'disabled',
+              enabled: true,
+            },
+          },
+          {
+            name: 'ocp-advisor-ui-upgrade-risks',
             enabled: false,
             variant: {
               name: 'disabled',

--- a/src/Components/ClustersListTable/ClustersListTable.cy.js
+++ b/src/Components/ClustersListTable/ClustersListTable.cy.js
@@ -798,9 +798,36 @@ describe('update risk', () => {
   });
 });
 
-describe('update risk disabled', () => {
+describe('update risk enabled and ui flag disabled', () => {
   beforeEach(() => {
     featureFlagsInterceptors.upgradeRisksDisabled();
+  });
+
+  describe('two clusters enabled', () => {
+    beforeEach(() => {
+      clustersUpdateRisksInterceptors['successful, two labels']();
+      mountLessClusters();
+    });
+
+    it("doesn't displays two labels", () => {
+      cy.wait('@upgradeRisksFlagDisabled');
+      // Expect no requests
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(2000);
+      cy.get('@clustersUpdateRisksOKTwo.all').then((interceptions) => {
+        expect(interceptions).to.have.length(0);
+      });
+      cy.ouiaId('loading-skeleton').should('not.exist');
+      cy.get(
+        'span[class=pf-v5-c-label__content]:contains("Update risk")'
+      ).should('have.length', 0);
+    });
+  });
+});
+
+describe('both update risk flags disabled', () => {
+  beforeEach(() => {
+    featureFlagsInterceptors.upgradeRisksDisabled2();
   });
 
   describe('two clusters enabled', () => {

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -54,12 +54,16 @@ import {
 import { coerce } from 'semver';
 import { BASE_PATH } from '../../Routes';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
-import { useUpdateRisksFeatureFlag } from '../../Utilities/useFeatureFlag';
+import {
+  useUpdateRisksFeatureFlag,
+  useUpdateRisksUIFeatureFlag,
+} from '../../Utilities/useFeatureFlag';
 
 const ClustersListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
 }) => {
   const areUpdateRisksEnabled = useUpdateRisksFeatureFlag();
+  const areUpdateRisksUIEnabled = useUpdateRisksUIFeatureFlag();
   const intl = useIntl();
   const dispatch = useDispatch();
   const updateFilters = (payload) =>
@@ -106,7 +110,13 @@ const ClustersListTable = ({
     return () => {
       controller.abort();
     };
-  }, [filteredRows, filters.limit, filters.offset, areUpdateRisksEnabled]);
+  }, [
+    filteredRows,
+    filters.limit,
+    filters.offset,
+    areUpdateRisksEnabled,
+    areUpdateRisksUIEnabled,
+  ]);
 
   useEffect(() => {
     setRowsFiltered(false);
@@ -208,7 +218,11 @@ const ClustersListTable = ({
 
     const clusterArr = paginatedItems?.map((cluster) => cluster.it.cluster_id);
     let upgradeArr = [];
-    if (clusterArr?.length > 0 && areUpdateRisksEnabled) {
+    if (
+      clusterArr?.length > 0 &&
+      areUpdateRisksEnabled &&
+      areUpdateRisksUIEnabled
+    ) {
       let res = null;
       try {
         res = await axios.post(

--- a/src/Utilities/useFeatureFlag.js
+++ b/src/Utilities/useFeatureFlag.js
@@ -12,6 +12,9 @@ export default useFeatureFlag;
 export const UPDATE_RISKS_ENABLE_FLAG =
   'ocp-advisor.upgrade-risks.enable-in-stable';
 
+// Second feature flag for Update Risk Label in Clusters page
+export const UPDATE_RISKS_UI_ENABLE_FLAG = 'ocp-advisor-ui-upgrade-risks';
+
 export const WORKLOADS_ENABLE_FLAG = 'ocp-advisor-ui-workloads';
 
 export const useUpdateRisksFeatureFlag = () => {
@@ -19,6 +22,12 @@ export const useUpdateRisksFeatureFlag = () => {
   const chrome = useChrome();
 
   return chrome.isBeta() || updateRisksEnabled;
+};
+
+export const useUpdateRisksUIFeatureFlag = () => {
+  const updateRisksUIEnabled = useFeatureFlag(UPDATE_RISKS_UI_ENABLE_FLAG);
+
+  return updateRisksUIEnabled;
 };
 
 export const useWorkloadsFeatureFlag = () => {


### PR DESCRIPTION
There's a request for a second feature flag until the backend is sorted out.
The new feature flag is `ocp-advisor-ui-upgrade-risks`.
Should show the label only if it's enabled. To enable this feature both upgrade risks feature flags have to be enabled or in case of `preview/beta` env only this flag has to be enabled.