### PR TITLE
fix(NoTicket): remove second update risk ff

### DIFF
--- a/cypress/utils/interceptors.js
+++ b/cypress/utils/interceptors.js
@@ -197,14 +197,6 @@ export const featureFlagsInterceptors = {
               enabled: true,
             },
           },
-          {
-            name: 'ocp-advisor-ui-upgrade-risks',
-            enabled: true,
-            variant: {
-              name: 'disabled',
-              enabled: true,
-            },
-          },
         ],
       },
     }).as('upgradeRisksFlag');
@@ -216,39 +208,6 @@ export const featureFlagsInterceptors = {
         toggles: [
           {
             name: 'ocp-advisor.upgrade-risks.enable-in-stable',
-            enabled: true,
-            variant: {
-              name: 'disabled',
-              enabled: true,
-            },
-          },
-          {
-            name: 'ocp-advisor-ui-upgrade-risks',
-            enabled: false,
-            variant: {
-              name: 'disabled',
-              enabled: true,
-            },
-          },
-        ],
-      },
-    }).as('upgradeRisksFlagDisabled');
-  },
-  upgradeRisksDisabled2: () => {
-    cy.intercept('/feature_flags*', {
-      statusCode: 200,
-      body: {
-        toggles: [
-          {
-            name: 'ocp-advisor.upgrade-risks.enable-in-stable',
-            enabled: false,
-            variant: {
-              name: 'disabled',
-              enabled: true,
-            },
-          },
-          {
-            name: 'ocp-advisor-ui-upgrade-risks',
             enabled: false,
             variant: {
               name: 'disabled',

--- a/src/Components/ClustersListTable/ClustersListTable.cy.js
+++ b/src/Components/ClustersListTable/ClustersListTable.cy.js
@@ -798,36 +798,9 @@ describe('update risk', () => {
   });
 });
 
-describe('update risk enabled and ui flag disabled', () => {
+describe('update risk flag disabled', () => {
   beforeEach(() => {
     featureFlagsInterceptors.upgradeRisksDisabled();
-  });
-
-  describe('two clusters enabled', () => {
-    beforeEach(() => {
-      clustersUpdateRisksInterceptors['successful, two labels']();
-      mountLessClusters();
-    });
-
-    it("doesn't displays two labels", () => {
-      cy.wait('@upgradeRisksFlagDisabled');
-      // Expect no requests
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(2000);
-      cy.get('@clustersUpdateRisksOKTwo.all').then((interceptions) => {
-        expect(interceptions).to.have.length(0);
-      });
-      cy.ouiaId('loading-skeleton').should('not.exist');
-      cy.get(
-        'span[class=pf-v5-c-label__content]:contains("Update risk")'
-      ).should('have.length', 0);
-    });
-  });
-});
-
-describe('both update risk flags disabled', () => {
-  beforeEach(() => {
-    featureFlagsInterceptors.upgradeRisksDisabled2();
   });
 
   describe('two clusters enabled', () => {

--- a/src/Components/ClustersListTable/ClustersListTable.js
+++ b/src/Components/ClustersListTable/ClustersListTable.js
@@ -54,16 +54,12 @@ import {
 import { coerce } from 'semver';
 import { BASE_PATH } from '../../Routes';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
-import {
-  useUpdateRisksFeatureFlag,
-  useUpdateRisksUIFeatureFlag,
-} from '../../Utilities/useFeatureFlag';
+import { useUpdateRisksFeatureFlag } from '../../Utilities/useFeatureFlag';
 
 const ClustersListTable = ({
   query: { isError, isUninitialized, isFetching, isSuccess, data, refetch },
 }) => {
   const areUpdateRisksEnabled = useUpdateRisksFeatureFlag();
-  const areUpdateRisksUIEnabled = useUpdateRisksUIFeatureFlag();
   const intl = useIntl();
   const dispatch = useDispatch();
   const updateFilters = (payload) =>
@@ -110,13 +106,7 @@ const ClustersListTable = ({
     return () => {
       controller.abort();
     };
-  }, [
-    filteredRows,
-    filters.limit,
-    filters.offset,
-    areUpdateRisksEnabled,
-    areUpdateRisksUIEnabled,
-  ]);
+  }, [filteredRows, filters.limit, filters.offset, areUpdateRisksEnabled]);
 
   useEffect(() => {
     setRowsFiltered(false);
@@ -218,11 +208,7 @@ const ClustersListTable = ({
 
     const clusterArr = paginatedItems?.map((cluster) => cluster.it.cluster_id);
     let upgradeArr = [];
-    if (
-      clusterArr?.length > 0 &&
-      areUpdateRisksEnabled &&
-      areUpdateRisksUIEnabled
-    ) {
+    if (clusterArr?.length > 0 && areUpdateRisksEnabled) {
       let res = null;
       try {
         res = await axios.post(

--- a/src/Utilities/useFeatureFlag.js
+++ b/src/Utilities/useFeatureFlag.js
@@ -12,9 +12,6 @@ export default useFeatureFlag;
 export const UPDATE_RISKS_ENABLE_FLAG =
   'ocp-advisor.upgrade-risks.enable-in-stable';
 
-// Second feature flag for Update Risk Label in Clusters page
-export const UPDATE_RISKS_UI_ENABLE_FLAG = 'ocp-advisor-ui-upgrade-risks';
-
 export const WORKLOADS_ENABLE_FLAG = 'ocp-advisor-ui-workloads';
 
 export const useUpdateRisksFeatureFlag = () => {
@@ -22,12 +19,6 @@ export const useUpdateRisksFeatureFlag = () => {
   const chrome = useChrome();
 
   return chrome.isBeta() || updateRisksEnabled;
-};
-
-export const useUpdateRisksUIFeatureFlag = () => {
-  const updateRisksUIEnabled = useFeatureFlag(UPDATE_RISKS_UI_ENABLE_FLAG);
-
-  return updateRisksUIEnabled;
 };
 
 export const useWorkloadsFeatureFlag = () => {


### PR DESCRIPTION
According to [this](https://redhat-internal.slack.com/archives/CLABA9CHY/p1714653331074799?thread_ts=1714482718.650039&cid=CLABA9CHY), the issue was fixed and we're free to remove the feature flag.

How to test:
1. **Enable** the `ocp-advisor-ui-upgrade-risks` ff on unleash stage.
2. Go to Cluster list page
3. Make sure the `/upgrade-risks-prediction` endpoint is called
4. **Disable** the `ocp-advisor-ui-upgrade-risks` ff on unleash stage
5. Go to Cluster list page
6. Make sure the `/upgrade-risks-prediction` endpoint is still called

After the PR is approved, I'll remove the flag on unleash stage. After release it will be removed on prod.

