### PR TITLE
Fix missing await and add tests

### DIFF
--- a/src/Components/Modals/DisableRule.cy.js
+++ b/src/Components/Modals/DisableRule.cy.js
@@ -181,7 +181,7 @@ describe('modal with multiple hosts', () => {
   });
 });
 
-describe.only('call order checking', () => {
+describe('call order checking', () => {
   it('single host', () => {
     let responded = false;
 

--- a/src/Components/Modals/DisableRule.cy.js
+++ b/src/Components/Modals/DisableRule.cy.js
@@ -213,6 +213,7 @@ describe.only('call order checking', () => {
 
     cy.ouiaId(SAVE_BUTTON).click();
     // wait for half the delay time, we expect the machine to be able to respond faster
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(1000).then(() => expect(responded).to.be.false);
   });
 
@@ -255,6 +256,7 @@ describe.only('call order checking', () => {
 
     cy.ouiaId(SAVE_BUTTON).click();
     // wait for half the delay time, we expect the machine to be able to respond faster
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(1000).then(() => expect(responded).to.be.false);
   });
 
@@ -284,6 +286,7 @@ describe.only('call order checking', () => {
 
     cy.ouiaId(SAVE_BUTTON).click();
     // wait for half the delay time, we expect the machine to be able to respond faster
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(1000).then(() => expect(responded).to.be.false);
   });
 });

--- a/src/Components/Modals/DisableRule.js
+++ b/src/Components/Modals/DisableRule.js
@@ -75,7 +75,7 @@ const DisableRule = ({
           title: intl.formatMessage(messages.recSuccessfullyDisabledForCluster),
         });
       } else if (multipleHosts) {
-        bulkHostActions();
+        await bulkHostActions();
       } else {
         // disable the whole rec
         await setAck({


### PR DESCRIPTION
The modal to disable clusters was not waiting for an async operation to complete. Thus, follow up actions (getting the fresh data from backend) were triggered before all changes were submitted. As such,the view was not consistent.

Test for this have been added.

Fixes [RHINENG-10897](https://issues.redhat.com/browse/RHINENG-10897)

The test added here require a revisit, as the implementation is not the best one.
I have tried something more elaborated, but did not work as expected. Advice will be appreciated.

```
describe.only('call order checking', () => {
  it('single host', () => {
    let number_of_calls = 0;
    let calls_so_far = 0;

    cy.mount(
      <MemoryRouter>
        <Intl>
          <Provider store={getStore()}>
            <DisableRule
              isModalOpen={true}
              rule={{ rule_id: 'foo|BAR', disabled: false }}
              host={'7795cbcd-0353-4e59-b920-fc1c39a27014'}
              afterFn={() => {
                // trick, as an expect here does not raise an error in the tests
                calls_so_far = number_of_calls;
                // expect(number_of_calls).to.equal(1);
              }}
            />
          </Provider>
        </Intl>
      </MemoryRouter>
    );

    cy.intercept(
      'PUT',
      '/api/insights-results-aggregator/v1/clusters/**/rules/**/error_key/**/disable',
      (req) => {
        req.on('after:response', () => {
          number_of_calls++;
        });
        req.reply({
          statusCode: 200,
          delay: 2 * 1000, // 2 secs
        });
      }
    ).as('disableRequest');

    cy.ouiaId(SAVE_BUTTON).click();
    cy.wait('@disableRequest').then(() => {
     expect(calls_so_far).to.equal(1);
    });
  });

  it('multiple hosts', () => {
    let number_of_calls = 0;
    let calls_so_far = 0;

    // beforeEach(() => {
    cy.mount(
      <MemoryRouter>
        <Intl>
          <Provider store={getStore()}>
            <DisableRule
              isModalOpen={true}
              rule={{ rule_id: 'foo|BAR', disabled: false }}
              hosts={[
                {
                  id: '084ac7a7-1c7d-49ff-b56e-f94881da242d',
                },
                {
                  id: '7795cbcd-0353-4e59-b920-fc1c39a27014',
                },
              ]}
              afterFn={() => {
                // trick, as an expect here does not raise an error in the tests
                calls_so_far = number_of_calls;
                // expect(number_of_calls).to.equal(2);
              }}
            />
          </Provider>
        </Intl>
      </MemoryRouter>
    );

    cy.intercept(
      'PUT',
      '/api/insights-results-aggregator/v1/clusters/**/rules/**/error_key/**/disable',
      (req) => {
        req.on('after:response', () => {
          number_of_calls++;
        });
        req.reply({
          statusCode: 200,
          delay: 2 * 1000, // 2 secs
        });
      }
    ).as('disableRequest');

    cy.ouiaId(SAVE_BUTTON).click();
    cy.wait(['@disableRequest', '@disableRequest']).then(() => {
      expect(calls_so_far).to.equal(2);
    });
  });

  it('no hosts', () => {
    let number_of_calls = 0;
    let calls_so_far = 0;

    cy.mount(
      <MemoryRouter>
        <Intl>
          <Provider store={getStore()}>
            <DisableRule
              isModalOpen={true}
              rule={{ rule_id: 'abc', disabled: false }}
              afterFn={() => {
                // trick, as an expect here does not raise an error in the tests
                calls_so_far = number_of_calls;
                // expect(number_of_calls).to.equal(1);
              }}
            />
          </Provider>
        </Intl>
      </MemoryRouter>
    );

    cy.intercept('POST', '/api/insights-results-aggregator/v2/ack', (req) => {
      req.on('after:response', () => {
        number_of_calls++;
      });
      req.reply({
        statusCode: 200,
        delay: 2 * 1000, // 2 secs
      });
    }).as('ackRequest');

    cy.ouiaId(SAVE_BUTTON).click();
    cy.wait('@ackRequest').then(() => {
      expect(calls_so_far).to.equal(1);
    });
  });
});```