### PR TITLE
feat(RHINENG-19797): add lightspeed rebrand with feature flag

### DIFF
--- a/src/Components/MessageState/EmptyStates.js
+++ b/src/Components/MessageState/EmptyStates.js
@@ -30,6 +30,7 @@ import DefaultErrorMessage from '@redhat-cloud-services/frontend-components/Erro
 import MessageState from './MessageState';
 import messages from '../../Messages';
 import { BASE_PATH } from '../../Routes';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 // Analogue for ErrorState from the frontend-components without the "Go to homepage" button
 // TODO: update ErrorState from the frontend-components and remove custom error here
@@ -108,6 +109,7 @@ const ComingSoon = () => {
 };
 
 const NoRecsForClusters = () => {
+  const lightspeedFeatureFlag = useFeatureFlag('platform.lightspeed-rebrand');
   const intl = useIntl();
   return (
     <EmptyState variant="sm">
@@ -119,7 +121,11 @@ const NoRecsForClusters = () => {
         headingLevel="h2"
       />
       <EmptyStateBody>
-        {intl.formatMessage(messages.noRecsForClusterListBody)}
+        {intl.formatMessage(
+          lightspeedFeatureFlag
+            ? messages.noRecsForClusterListBodyLightspeed
+            : messages.noRecsForClusterListBody
+        )}
       </EmptyStateBody>
       <EmptyStateFooter>
         <Button
@@ -151,13 +157,18 @@ const NoRecsForClusters = () => {
 };
 
 const NoInsightsResults = () => {
+  const lightspeedFeatureFlag = useFeatureFlag('platform.lightspeed-rebrand');
   const intl = useIntl();
   return (
     <MessageState
       title={intl.formatMessage(messages.noRecsFoundError)}
       text={
         <React.Fragment>
-          {intl.formatMessage(messages.noRecsFoundErrorDesc)}
+          {intl.formatMessage(
+            lightspeedFeatureFlag
+              ? messages.noRecsFoundErrorDescLightspeed
+              : messages.noRecsFoundErrorDesc
+          )}
           <a href="https://docs.openshift.com/container-platform/latest/support/getting-support.html">
             {' '}
             OpenShift documentation.

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -663,4 +663,16 @@ export default defineMessages({
     id: 'updateRisksNotCurrentlyAvailable',
     defaultMessage: 'Update risks are not currently available.',
   },
+  noRecsFoundErrorDescLightspeed: {
+    id: 'noRecsFoundErrorDescLightspeed',
+    description: 'Recommendations table, cluster recommendations table',
+    defaultMessage:
+      'Red Hat Lightspeed identifies and prioritizes risks to security, performance, availability, and stability of your clusters. This feature uses the Remote Health functionality of OpenShift Container Platform. For further details about Red Hat Lightspeed, see the',
+  },
+  noRecsForClusterListBodyLightspeed: {
+    id: 'noRecsForClusterListBodyLightspeed',
+    description: 'Cluster List Page received 0 clusters',
+    defaultMessage:
+      'To get started, create or register your cluster to get recommendations from Red Hat Lightspeed Advisor.',
+  },
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-19797
Added 2 messages for Lightspeed rebranding that are enabled when the feature flag is ON

How to test:
1) In the ClusterRules component, force the NoInsightsResults component to render with feature flag ON
2) In the ClusterListTable componen,t force the NoRecsForClusters component to render with feature flag ON