### PR TITLE
style: fix prettier formatting in UpdateRisksTable

### DIFF
--- a/src/Components/UpdateRisksTable/UpdateRisksTable.js
+++ b/src/Components/UpdateRisksTable/UpdateRisksTable.js
@@ -80,7 +80,8 @@ const UpdateRisksTable = () => {
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
                   {alertsDisabled
                     ? ALERTS_SEVERITY_ICONS['success']
-                    : ALERTS_SEVERITY_ICONS[ // this algorithm helps to decide which icon (the most severe) to show
+                    : ALERTS_SEVERITY_ICONS // this algorithm helps to decide which icon (the most severe) to show
+                      [
                         ALERTS_SEVERITY_ORDER.filter((s) =>
                           alerts.some(({ severity }) => s === severity),
                         )[0]


### PR DESCRIPTION
Prettier 3.9.6 requires the bracket accessor to be on its own line when preceded by a comment. This is a forward-compatible change that works with both 3.8.4 and 3.9.6.

Unblocks MintMaker PRs:
- #1170
- #1171