### PR TITLE
chore(tekton): bump konflux-pipelines to v1.71.0

### DIFF
--- a/.tekton/ocp-advisor-frontend-pull-request.yaml
+++ b/.tekton/ocp-advisor-frontend-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: insights-ocp-advisor

--- a/.tekton/ocp-advisor-frontend-push.yaml
+++ b/.tekton/ocp-advisor-frontend-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-ocp-advisor


### PR DESCRIPTION
## Summary

Bumps the Konflux pipeline reference in both `.tekton` files from `v1.70.0` to `v1.71.0`.

This fixes failing **enterprise contract** checks on this repo (including MintMaker auto-merge PRs #1179 and #1180). The GitHub `test` workflow and Konflux **build** pipeline were already passing; EC was the blocker.

## Why this is needed

`Red Hat Konflux / insights-ocp-advisor-frontend-enterprise-contract` fails with **6 violations**, all the same rule:

- `trusted_task.trusted` / `tasks.required_untrusted_task_found`
- Task: `prefetch-dependencies-oci-ta`
- Message: *"Untrusted version of PipelineTask prefetch-dependencies … denial reason is: deny_rule"*

Example PipelineRuns (from failing bot PRs on 2026-08-14):

- `insights-ocp-advisor-frontend-enterprise-contract-qxmpf` (#1180)
- `insights-ocp-advisor-frontend-enterprise-contract-rfd64` (#1179)

Master has the same EC failure since the 2026-08-13 push (`insights-ocp-advisor-frontend-enterprise-contract-2ltnr`).

### Root cause

Our `.tekton` files pin:

```text
konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
```

That pipeline version resolves `prefetch-dependencies` to a Tekton task digest that EC policy now **denies**:

```text
quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
```

`konflux-pipelines` **v1.71.0** (released 2026-08-12) updates this to a newer trusted digest:

```text
quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:b8c8ad3f6e0a89a498ace429b81c4b334241d4f8bab2f16dc3dcb3c55db85456
```

## Validation

Tested on this PR before marking ready:

| Check | v1.70.0 (before) | v1.71.0 (this PR) |
| --- | --- | --- |
| `ocp-advisor-frontend-on-pull-request` | pass | **pass** |
| `insights-ocp-advisor-frontend-enterprise-contract` | **fail** (6 violations) | **neutral** (132 pass, 3 warnings) |
| GitHub `test` | pass | **pass** |

After merge, MintMaker PRs blocked only on EC should be able to proceed once rebased/retested:

- #1180 — npm minor/patch deps (lockfile already fixed)
- #1179 — build-tools digest (tests already green)